### PR TITLE
Non-functional tweak for bash coding standards

### DIFF
--- a/examples/mapColoringUSStates/plotmap.sh
+++ b/examples/mapColoringUSStates/plotmap.sh
@@ -13,20 +13,14 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-if [ "$1" == "" ]
-then
-    adj="blank_US_state_map.svg"
-else
-    adj=$1
-fi
-prwd=`pwd`
+adj=${1:-"blank_US_state_map.svg"}
+prwd=$(pwd)
+
 for qbouts in *.qbout
-do
-    echo $qbouts $adj $xsplits
+do  echo $qbouts $adj $xsplits
     split -l 5 $qbouts
     for xsplits in x*
-    do
-        python color_states.py -i $prwd/$xsplits -s $prwd/${adj} -o $prwd/${qbouts}.${xsplits}.svg
+    do  python color_states.py -i $prwd/$xsplits -s $prwd/${adj} -o $prwd/${qbouts}.${xsplits}.svg
     done
     rm $prwd/x*
 done


### PR DESCRIPTION
I'm not sure if you want to bother with these sorts of changes, but I'll submit this anyway.  I tested that the change was neutral by running the following code in a Bash terminal:

lambduh() {
   if [ "$1" == "" ]
   then
       adj="blank_US_state_map.svg"
   else
       adj=$1
   fi

   prwd=`pwd`

   echo "old way: prwd $prwd , adj $adj"

   adj=${1:-"blank_US_state_map.svg"}
   prwd=$(pwd)

   echo "new way: prwd $prwd , adj $adj"
}

sheeple() {
   echo begin tests

   echo passing override
   lambduh override.svg

   echo passing nothing
   lambduh

   echo passing an empty string
   lambduh ""

   echo done
}

sheeple
