### PR TITLE
Haiku support: this major change lets qbsolv compiled on Haiku

### DIFF
--- a/src/solver.c
+++ b/src/solver.c
@@ -397,7 +397,7 @@ void solve(double **val, int maxNodes)
 	}
 
 	// get some memory for storing and shorting Q bit vectors
-	const int QLEN 20;
+	const int QLEN=20;
 	short  **Qlist;
 	double *QVs;
 	int    *Qcounts, *Qindex, NU = 0; // NU = current count of items


### PR DESCRIPTION
Without it gcc 5 complains:

> solver.c:400:17: error: expected '=', ',', ';', 'asm' or '__attribute__' before numeric constant
>   const int QLEN 20;
>                  ^
> solver.c:405:38: error: 'QLEN' undeclared (first use in this function)
>   Qlist = (short**)malloc2D(maxNodes, QLEN + 1, sizeof(short));
