### PR TITLE
Replace code indentation TABs with spaces

### DIFF
--- a/src/debugs.c
+++ b/src/debugs.c
@@ -20,107 +20,107 @@
 // this DEBUG function just checks for a corrupt Q bit vector
 int check_corrupt_Q(int8_t *Q, int N)
 {
-	int i;
-	int ret;
+    int i;
+    int ret;
 
-	ret = false;
-	for (i = 0; i < N; i++) {
-		if (Q[i] / 2 != 0 ) {  // this is not a 1 or zero
-			printf("Q not 1 or zero , Q %d i %d\n", Q[i], i);
-			exit(9);
-			ret = true;
-		}
-	}
-	return ret;
+    ret = false;
+    for (i = 0; i < N; i++) {
+        if (Q[i] / 2 != 0 ) {  // this is not a 1 or zero
+            printf("Q not 1 or zero , Q %d i %d\n", Q[i], i);
+            exit(9);
+            ret = true;
+        }
+    }
+    return ret;
 }
 
 // this DEBUG function just checks for a corrupt tabu list
 int check_corrupt_tabu(int *T, int N, int nTabu)
 {
-	int i;
-	int ret;
+    int i;
+    int ret;
 
-	ret = false;
-	for (i = 0; i < N; i++) {
-		if ((T[i] > nTabu) | (T[i] < 0) ) {  // this is not out of Range
-			printf("Tabu is not in Range , Tabu[%d] = %d\n", i, T[i]);
-			exit(9);
-			ret = true;
-		}
-	}
-	return ret;
+    ret = false;
+    for (i = 0; i < N; i++) {
+        if ((T[i] > nTabu) | (T[i] < 0) ) {  // this is not out of Range
+            printf("Tabu is not in Range , Tabu[%d] = %d\n", i, T[i]);
+            exit(9);
+            ret = true;
+        }
+    }
+    return ret;
 }
 
 // this DEBUG function evaluates the objective function for a given Q, with no optimizations ( the long way )
 double just_evaluate(int8_t *Q, int maxNodes, double **val)
 {
-	int    i, j;
-	double result = 0.0;
+    int    i, j;
+    double result = 0.0;
 
-	for (i = 0; i < maxNodes; i++) {
-		for ( j = i; j < maxNodes; j++) {
-			result += val[i][j] * (double)Q[j] * (double)Q[i];
-		}
-	}
-	return result;
+    for (i = 0; i < maxNodes; i++) {
+        for ( j = i; j < maxNodes; j++) {
+            result += val[i][j] * (double)Q[j] * (double)Q[i];
+        }
+    }
+    return result;
 }
 
 // this DEBUG function evaluates the validity of the Qval difference vector Qval, and it will abort if there is a problem
 // Qval = the change if a Q bit is flipped
 void check_row_col_qval(int8_t *Q, int maxNodes, double **val, double *Qval, double *Row, double *Col)
 {
-	int    i, j;
-	double Cols, Rows, Qvals;
+    int    i, j;
+    double Cols, Rows, Qvals;
 
-	for (i = 0; i < maxNodes; i++) {
-		Rows = 0.0; Cols = 0.0;
+    for (i = 0; i < maxNodes; i++) {
+        Rows = 0.0; Cols = 0.0;
 
-		for ( j = i + 1; j < maxNodes; j++) {
-			Rows += val[i][j] * (double)Q[j];
-		}
-		for ( j = 0; j < i; j++) {
-			Cols += val[j][i] * (double)Q[j];
-		}
+        for ( j = i + 1; j < maxNodes; j++) {
+            Rows += val[i][j] * (double)Q[j];
+        }
+        for ( j = 0; j < i; j++) {
+            Cols += val[j][i] * (double)Q[j];
+        }
 
-		if ( Q[i] == 1 ) {
-			Qvals = -( Rows + Cols + val[i][i] );
-		} else {
-			Qvals =  ( Rows + Cols + val[i][i] );
-		}
-		if ( ( Rows != Row[i] ) | (Cols != Col[i]) | ( Qvals != Qval[i])) {
-			printf(" i = %d  Q[i] = %d  Row to Row[i] %.10e  %.10e  Col to Col[i] %.10e  %.10e  Qval to Qval[i] %.10e  %.10e \n",
-			       i, Q[i], Rows, Row[i], Cols, Col[i], Qvals, Qval[i]);
-		}
-	}
-	return;
+        if ( Q[i] == 1 ) {
+            Qvals = -( Rows + Cols + val[i][i] );
+        } else {
+            Qvals =  ( Rows + Cols + val[i][i] );
+        }
+        if ( ( Rows != Row[i] ) | (Cols != Col[i]) | ( Qvals != Qval[i])) {
+            printf(" i = %d  Q[i] = %d  Row to Row[i] %.10e  %.10e  Col to Col[i] %.10e  %.10e  Qval to Qval[i] %.10e  %.10e \n",
+                   i, Q[i], Rows, Row[i], Cols, Col[i], Qvals, Qval[i]);
+        }
+    }
+    return;
 }
 
 // this DEBUG function checks the Qval vector
 void check_Qval(int8_t *Q, int maxNodes, double **val, double *Qval)
 {
-	//  checking the Qval vector
-	double result, just_result;
-	int    i;
+    //  checking the Qval vector
+    double result, just_result;
+    int    i;
 
-	check_corrupt_Q(Q, maxNodes);
-	result = just_evaluate(Q, maxNodes, val);
-	check_corrupt_Q(Q, maxNodes);
-	int fail = false;
-	for (i = 0; i < maxNodes; i++) {
-		Q[i] = 1 - Q[i];
-		just_result = just_evaluate(Q, maxNodes, val);
-		check_corrupt_Q(Q, maxNodes);
-		if ( just_result != result + Qval[i]) {
-			DL;
-			printf("Qval failure i=%d, just_result=%.10e, Qval + result = %.10e,Qval[i]= %.10e ,Q=%d\n", \
-			       i, just_result, result + Qval[i], Qval[i], Q[i]);
-			fail = true;
-		}
-		Q[i] = 1 - Q[i];
-	}
-	if ( fail ) {
-
-		print_solution_and_qubo(Q, maxNodes, val);
-		exit(9);
-	}
+    check_corrupt_Q(Q, maxNodes);
+    result = just_evaluate(Q, maxNodes, val);
+    check_corrupt_Q(Q, maxNodes);
+    int fail = false;
+    for (i = 0; i < maxNodes; i++) {
+        Q[i] = 1 - Q[i];
+        just_result = just_evaluate(Q, maxNodes, val);
+        check_corrupt_Q(Q, maxNodes);
+        if ( just_result != result + Qval[i]) {
+            DL;
+            printf("Qval failure i=%d, just_result=%.10e, Qval + result = %.10e,Qval[i]= %.10e ,Q=%d\n", \
+                   i, just_result, result + Qval[i], Qval[i], Q[i]);
+            fail = true;
+        }
+        Q[i] = 1 - Q[i];
+    }
+    if ( fail ) {
+        
+        print_solution_and_qubo(Q, maxNodes, val);
+        exit(9);
+    }
 }

--- a/src/dwsolv.c
+++ b/src/dwsolv.c
@@ -18,7 +18,7 @@
  * More information needed, please provide
  *
  * Why is this only used when SubMatrix_ == 0?
-*/
+ */
 
 #include "include.h"
 #include "extern.h" // qubo header file: global variable declarations
@@ -52,179 +52,179 @@ int  i, j, k, l; // working integer set
 
 void dw_init()
 {
-	// checks to see that all environment variables are in place, along with
-	// .epqmi file and path needed to embed problems to the solver
-	char filename_max_full[256];
-	char linebuf[256];
+    // checks to see that all environment variables are in place, along with
+    // .epqmi file and path needed to embed problems to the solver
+    char filename_max_full[256];
+    char linebuf[256];
 
-	mingw_base_len = strlen("MINGWGINK"); // more Ridiculous MinGW workaround
-	my_pid_ = getpid(); // will use for /tmp filename base
+    mingw_base_len = strlen("MINGWGINK"); // more Ridiculous MinGW workaround
+    my_pid_ = getpid(); // will use for /tmp filename base
 
-	workspace = getenv(DW_INTERNAL__WORKSPACE);
-	if ( workspace == NULL ) {
-		printf(" dw workspace not set up \n");
-		DW_setup_error = true;
-	}
-	connection = getenv(DW_INTERNAL__CONNECTION);
-	if ( connection == NULL ) {
-		printf(" dw connection not set up \n");
-		DW_setup_error = true;
-	}
-	wspath = getenv(DW_INTERNAL__WSPATH);
-	if ( wspath == NULL ) {
-		printf(" dw wspath not set up \n");
-		DW_setup_error = true;
-	} else {
+    workspace = getenv(DW_INTERNAL__WORKSPACE);
+    if ( workspace == NULL ) {
+        printf(" dw workspace not set up \n");
+        DW_setup_error = true;
+    }
+    connection = getenv(DW_INTERNAL__CONNECTION);
+    if ( connection == NULL ) {
+        printf(" dw connection not set up \n");
+        DW_setup_error = true;
+    }
+    wspath = getenv(DW_INTERNAL__WSPATH);
+    if ( wspath == NULL ) {
+        printf(" dw wspath not set up \n");
+        DW_setup_error = true;
+    } else {
 
-		if (strncmp(wspath, mingw_base, mingw_base_len) == 0)
-			wspath += mingw_base_len; // completed RMWorkaround
+        if (strncmp(wspath, mingw_base, mingw_base_len) == 0)
+            wspath += mingw_base_len; // completed RMWorkaround
 
-		sprintf(filename_max_full, "%s/.max_full", workspace);
+        sprintf(filename_max_full, "%s/.max_full", workspace);
 
-		if ((fs = fopen(filename_max_full, "r")) == NULL) {
-			printf(" no file %s\n", filename_max_full);
-			exit(9);
-		}
+        if ((fs = fopen(filename_max_full, "r")) == NULL) {
+            printf(" no file %s\n", filename_max_full);
+            exit(9);
+        }
 
-		if ( fscanf(fs, "%s", linebuf) == 0 ) {
-			DL; printf("fscanf error");
-			exit(9);
-		}
+        if ( fscanf(fs, "%s", linebuf) == 0 ) {
+            DL; printf("fscanf error");
+            exit(9);
+        }
 
-		fclose(fs);
-		sprintf(ws_tmp_path, "/%s", linebuf);
-	}
-	solver = getenv(DW_INTERNAL__SOLVER);
-	if ( solver == NULL ) {
-		printf(" dw solver not set up \n");
-		DW_setup_error = true;
-	}
-	if ( DW_setup_error == true ) {
-		printf(" dw not set up not complete, and -S 0 set \n");
-		DL; printf(" Exiting\n");
-		exit(9);
-	}
+        fclose(fs);
+        sprintf(ws_tmp_path, "/%s", linebuf);
+    }
+    solver = getenv(DW_INTERNAL__SOLVER);
+    if ( solver == NULL ) {
+        printf(" dw solver not set up \n");
+        DW_setup_error = true;
+    }
+    if ( DW_setup_error == true ) {
+        printf(" dw not set up not complete, and -S 0 set \n");
+        DL; printf(" Exiting\n");
+        exit(9);
+    }
 
-	char filename_epqmi_max[256];
-	sprintf(filename_epqmi_max, "%s/%s/.epqmi_max", workspace, ws_tmp_path); // find the size of embeded file
-	if ((fs = fopen(filename_epqmi_max, "r")) == NULL) {
-		printf(" no file %s\n", filename_epqmi_max);
-		exit(9);
-	}
+    char filename_epqmi_max[256];
+    sprintf(filename_epqmi_max, "%s/%s/.epqmi_max", workspace, ws_tmp_path); // find the size of embeded file
+    if ((fs = fopen(filename_epqmi_max, "r")) == NULL) {
+        printf(" no file %s\n", filename_epqmi_max);
+        exit(9);
+    }
 
-	int  S_embed;
-	if ( fscanf(fs, "%d", &S_embed) == 0 ) {
-		DL; printf("fscanf error");
-		exit(9);
-	}
-	SubMatrix_ = S_embed;
-	fclose(fs);
+    int  S_embed;
+    if ( fscanf(fs, "%d", &S_embed) == 0 ) {
+        DL; printf("fscanf error");
+        exit(9);
+    }
+    SubMatrix_ = S_embed;
+    fclose(fs);
 
-	if ( (sysResult = setenv(DW_INTERNAL__WSPATH, ws_tmp_path, 1)) != 0 ) {
-		printf(" result of call %d\n", sysResult);
-		printf(" Error making setenv call %s %s \n", "DW_INTERNAL_WSPATH", ws_tmp_path);
-		DL; printf(" setenv command failed \n");
-		exit(9);
-	}
-	strcpy(tmp_path, "/tmp");
+    if ( (sysResult = setenv(DW_INTERNAL__WSPATH, ws_tmp_path, 1)) != 0 ) {
+        printf(" result of call %d\n", sysResult);
+        printf(" Error making setenv call %s %s \n", "DW_INTERNAL_WSPATH", ws_tmp_path);
+        DL; printf(" setenv command failed \n");
+        exit(9);
+    }
+    strcpy(tmp_path, "/tmp");
 
-	wspath = getenv(DW_INTERNAL__WSPATH);  // read again, as it was set
+    wspath = getenv(DW_INTERNAL__WSPATH);  // read again, as it was set
 
-	if ( (SubMatrix_ < 10) | (SubMatrix_ > 100) ) {
-		DL; printf(" Retrieved a incorrect embedding size, %d  \n", SubMatrix_);
-		printf(" Exiting\n");
-		exit(9);
-	}
+    if ( (SubMatrix_ < 10) | (SubMatrix_ > 100) ) {
+        DL; printf(" Retrieved a incorrect embedding size, %d  \n", SubMatrix_);
+        printf(" Exiting\n");
+        exit(9);
+    }
 
-	if (Verbose_ > 2) {
-		DLT; DL;
-		if ( UseDwave_ ) {
-			printf(" UseDwave = true\n");
-		} else{
-			printf(" UseDwave = false\n");
-		}
-		printf(" SubMatrix_ = %d\n", SubMatrix_);
-		printf(" %s %s \n", DW_INTERNAL__WORKSPACE, workspace);
-		printf(" %s %s \n", DW_INTERNAL__CONNECTION, connection);
-		printf(" %s %s \n", DW_INTERNAL__WSPATH, wspath);
-		printf(" %s %s \n", DW_INTERNAL__SOLVER, solver);
-	}
+    if (Verbose_ > 2) {
+        DLT; DL;
+        if ( UseDwave_ ) {
+            printf(" UseDwave = true\n");
+        } else{
+            printf(" UseDwave = false\n");
+        }
+        printf(" SubMatrix_ = %d\n", SubMatrix_);
+        printf(" %s %s \n", DW_INTERNAL__WORKSPACE, workspace);
+        printf(" %s %s \n", DW_INTERNAL__CONNECTION, connection);
+        printf(" %s %s \n", DW_INTERNAL__WSPATH, wspath);
+        printf(" %s %s \n", DW_INTERNAL__SOLVER, solver);
+    }
 }
 
 void dw_solver(double **val, int maxNodes, int8_t *Q)
 {
-	// bind to .epqmi
-	char filename_b[256];
-	char filename_result[256];
+    // bind to .epqmi
+    char filename_b[256];
+    char filename_result[256];
 
-	sprintf(filename_b, "%s/qbs%d.b", tmp_path, my_pid_); // we will need to write b file to /tmp directory
+    sprintf(filename_b, "%s/qbs%d.b", tmp_path, my_pid_); // we will need to write b file to /tmp directory
 
-	if ((f = fopen(filename_b, "w")) == NULL ) {
-		DL; printf("  Failed open %s\n", filename_b);
-		exit(9);
-	}
+    if ((f = fopen(filename_b, "w")) == NULL ) {
+        DL; printf("  Failed open %s\n", filename_b);
+        exit(9);
+    }
 
-	// dwave finds minimum, while our tabu finds max, so send negative to dwave
-	for (i = 0; i < maxNodes; i++) {
-		fprintf(f, "a_%d = %6.3f\n", i + 1, -val[i][i]);
-	}
-	for (i = 0; i < maxNodes; i++) {
-		for (j = i + 1; j < maxNodes; j++) {
-			fprintf(f, "b_%d_%d = %6.3f\n", i + 1, j + 1, -val[i][j]);
-		}
-	}
-	fclose(f);
+    // dwave finds minimum, while our tabu finds max, so send negative to dwave
+    for (i = 0; i < maxNodes; i++) {
+        fprintf(f, "a_%d = %6.3f\n", i + 1, -val[i][i]);
+    }
+    for (i = 0; i < maxNodes; i++) {
+        for (j = i + 1; j < maxNodes; j++) {
+            fprintf(f, "b_%d_%d = %6.3f\n", i + 1, j + 1, -val[i][j]);
+        }
+    }
+    fclose(f);
 
-	// What does this do?
-	sprintf(DWcommand, "bash -c \'dw bind param_chain=15.0 /tmp/qbs%d.b  > /dev/null;"
-	        "dw exec num_reads=10 qbs%d.qmi  > /dev/null;"
-	        "dw val -s 1 qbs%d.sol |tail -n%d|cut -f3 -d\" \" > /tmp/qbs%d.xB\' \n",
-	        my_pid_, my_pid_, my_pid_, maxNodes, my_pid_);
-	sysResult = system(DWcommand);
-	if (sysResult != 0 ) {
-		DL; printf("system call error %d\n %s\n", sysResult, DWcommand);
-		exit(9);
-	}
-	if (Verbose_ > 2) printf("%s\n", DWcommand);
-	sprintf(filename_result, "%s/qbs%d.xB", tmp_path, my_pid_);
-	if ((fr = fopen(filename_result, "r")) == NULL ) {
-		DL; printf("  Failed open %s\n", filename_result); exit(9);
-	}
-	int8_t qtmp;
-	for (i = 0; i < maxNodes; i++) {
-		if ((fscanf(fr, "%hhd", &qtmp)) == 0 ) {
-			DL; printf("fscanf error %s", filename_result); exit(9);
-		}
-		Q[i] = qtmp;
-	}
-	if (Verbose_ > 3) {
-		printf("\nBits set after Dwave solver   ");
-		for (i = 0; i < maxNodes; i++) printf("%d", Q[i]);
-		printf("\n");
-	}
-	fclose(fr);
-
-	return;
+    // What does this do?
+    sprintf(DWcommand, "bash -c \'dw bind param_chain=15.0 /tmp/qbs%d.b  > /dev/null;"
+            "dw exec num_reads=10 qbs%d.qmi  > /dev/null;"
+            "dw val -s 1 qbs%d.sol |tail -n%d|cut -f3 -d\" \" > /tmp/qbs%d.xB\' \n",
+            my_pid_, my_pid_, my_pid_, maxNodes, my_pid_);
+    sysResult = system(DWcommand);
+    if (sysResult != 0 ) {
+        DL; printf("system call error %d\n %s\n", sysResult, DWcommand);
+        exit(9);
+    }
+    if (Verbose_ > 2) printf("%s\n", DWcommand);
+    sprintf(filename_result, "%s/qbs%d.xB", tmp_path, my_pid_);
+    if ((fr = fopen(filename_result, "r")) == NULL ) {
+        DL; printf("  Failed open %s\n", filename_result); exit(9);
+    }
+    int8_t qtmp;
+    for (i = 0; i < maxNodes; i++) {
+        if ((fscanf(fr, "%hhd", &qtmp)) == 0 ) {
+            DL; printf("fscanf error %s", filename_result); exit(9);
+        }
+        Q[i] = qtmp;
+    }
+    if (Verbose_ > 3) {
+        printf("\nBits set after Dwave solver   ");
+        for (i = 0; i < maxNodes; i++) printf("%d", Q[i]);
+        printf("\n");
+    }
+    fclose(fr);
+    
+    return;
 }
 
 void dw_close()
 {
-
-	sprintf(DWcommand, "rm -f %s/qbs%d* \n", tmp_path, my_pid_);
-
-	if (Verbose_ > 2) printf("%s", DWcommand);
-
-	if (system(DWcommand) != 0 ) {
-		DL; printf("system call error,%s", DWcommand);
-	} // clean up the /tmp directory
-
-	sprintf(DWcommand, "rm -f %s/%s/qbs%d.* \n", workspace, ws_tmp_path, my_pid_);
-
-	if (system(DWcommand) != 0 ) {
-		DL; printf("system call error,%s", DWcommand);
-	} // clean up the dw full.x directory
-
-	if (Verbose_ > 2) printf("%s", DWcommand);
-
-	return;
+    
+    sprintf(DWcommand, "rm -f %s/qbs%d* \n", tmp_path, my_pid_);
+    
+    if (Verbose_ > 2) printf("%s", DWcommand);
+    
+    if (system(DWcommand) != 0 ) {
+        DL; printf("system call error,%s", DWcommand);
+    } // clean up the /tmp directory
+    
+    sprintf(DWcommand, "rm -f %s/%s/qbs%d.* \n", workspace, ws_tmp_path, my_pid_);
+    
+    if (system(DWcommand) != 0 ) {
+        DL; printf("system call error,%s", DWcommand);
+    } // clean up the dw full.x directory
+    
+    if (Verbose_ > 2) printf("%s", DWcommand);
+    
+    return;
 }

--- a/src/include.h
+++ b/src/include.h
@@ -44,8 +44,8 @@
 
 // ----------------------- STRUCTs -------------------------------------
 struct nodeStr_ {
-	int32_t n1, n2;
-	double value;
+    int32_t n1, n2;
+    double value;
 };
 
 // ------------------- Prototypes --------------------------------------
@@ -80,7 +80,7 @@ void  val_index_sort(int *index, double *val, int n);
 void  val_index_sort_ns(int *index, double *val, int n);
 void  index_sort(int *index, int n, short FWD);
 int manage_solutions( int8_t *new_solution, int8_t **solution_list, double new_energy,
-	double *QVs, int *solution_counts, int *Qindex, int nMax, int nbits);
+                     double *QVs, int *solution_counts, int *Qindex, int nMax, int nbits);
 bool is_array_equal( int8_t *solution_now, int8_t *solution_other, int nbits);
 void dw_init( );
 void dw_solver( double **val, int maxNodes, int8_t *Q );

--- a/src/main.c
+++ b/src/main.c
@@ -40,314 +40,314 @@ const int defaultRepeats = 50;
 
 int  main( int argc,  char *argv[])
 {
-/*
- *  Initialize global variables, set up data structures,
- *  process the commandline and the environment, ...
- *  Initialize global variables
- */
-	extern char *optarg;
-	extern int  optind, optopt, opterr;
+    /*
+     *  Initialize global variables, set up data structures,
+     *  process the commandline and the environment, ...
+     *  Initialize global variables
+     */
+    extern char *optarg;
+    extern int  optind, optopt, opterr;
 
-	char *inFileName = NULL;
-	FILE *inFile    = NULL;
+    char *inFileName = NULL;
+    FILE *inFile    = NULL;
 
-	strcpy(pgmName_, "qbsolv");
-	findMax_     = false;
-	UseDwave_    = false;
-	Verbose_     = 0;
-	int nRepeats = defaultRepeats;
-	SubMatrix_   = 46; // submatrix default
-	strcpy(pgmName_, "o"); //algorithm default
+    strcpy(pgmName_, "qbsolv");
+    findMax_     = false;
+    UseDwave_    = false;
+    Verbose_     = 0;
+    int nRepeats = defaultRepeats;
+    SubMatrix_   = 46; // submatrix default
+    strcpy(pgmName_, "o"); //algorithm default
 
-	WriteMatrix_ = false;
-	outFile_     = stdout;
-	TargetSet_   = false;
-	Time_        = 2592000; // the maximum runtime of the algorithm in seconds before timeout (2592000 = a months worth of seconds)
-	Tlist_       = -1; // tabu list length  -1 signials go with defaults
-	int64_t seed       = 17932241798878;
-	int  errorCount = 0;
+    WriteMatrix_ = false;
+    outFile_     = stdout;
+    TargetSet_   = false;
+    Time_        = 2592000; // the maximum runtime of the algorithm in seconds before timeout (2592000 = a months worth of seconds)
+    Tlist_       = -1; // tabu list length  -1 signials go with defaults
+    int64_t seed       = 17932241798878;
+    int  errorCount = 0;
 
-	static struct option longopts[] = {
-		{ "help",           no_argument,       NULL, 'h'},
-		{ "infile",         required_argument, NULL, 'i'},
-		{ "outfile",        required_argument, NULL, 'o'},
-		{ "verbosityLevel", required_argument, NULL, 'v'},
-		{ "version",        no_argument,       NULL, 'V'},
-		{ "subproblemSize", required_argument, NULL, 'S'},
-		{ "target",         required_argument, NULL, 'T'},
-		{ "repeats",        required_argument, NULL, 'n'},
-		{ "max",            no_argument,       NULL, 'm'},
-		{ "output",         required_argument, NULL, 'o'},
-		{ "timeout",        required_argument, NULL, 't'},
-		{ "quboFormat",     no_argument,       NULL, 'q'},
-		{ "tlist",          required_argument, NULL, 'l'},
-		{ "seed",           required_argument, NULL, 'r'},
-		{ "Algo",           required_argument, NULL, 'a'},
-		{ NULL,             no_argument,       NULL, 0}
-	};
+    static struct option longopts[] = {
+        { "help",           no_argument,       NULL, 'h'},
+        { "infile",         required_argument, NULL, 'i'},
+        { "outfile",        required_argument, NULL, 'o'},
+        { "verbosityLevel", required_argument, NULL, 'v'},
+        { "version",        no_argument,       NULL, 'V'},
+        { "subproblemSize", required_argument, NULL, 'S'},
+        { "target",         required_argument, NULL, 'T'},
+        { "repeats",        required_argument, NULL, 'n'},
+        { "max",            no_argument,       NULL, 'm'},
+        { "output",         required_argument, NULL, 'o'},
+        { "timeout",        required_argument, NULL, 't'},
+        { "quboFormat",     no_argument,       NULL, 'q'},
+        { "tlist",          required_argument, NULL, 'l'},
+        { "seed",           required_argument, NULL, 'r'},
+        { "Algo",           required_argument, NULL, 'a'},
+        { NULL,             no_argument,       NULL, 0}
+    };
 
-	int  opt, option_index = 0;
-	char *chx; // used as exit ptr in strto(x) functions
+    int  opt, option_index = 0;
+    char *chx; // used as exit ptr in strto(x) functions
 
-	while ((opt = getopt_long(argc, argv, "Hhi:o:v:VS:T:l:n:wmo:t:qr:o:", longopts, &option_index)) != -1) {
-		switch (opt) {
-		case 'a':
-			break;
-		case 'H':
-		case 'h':
-			print_help();
-			exit(0);
-		case 'i':
-			inFileName = optarg;
-			if ((inFile = fopen(inFileName, "r")) == NULL) {
-				fprintf(stderr, "\n\t Error - can't find/open file " "\"%s\"\n\n", optarg);
-				exit(9);
-			}
-			break;
-		case 'l':
-			Tlist_ = strtol(optarg, &chx, 10); // this sets the length of the tabu list
-			break;
-		case 'm':
-			findMax_ = true; // go for the maximum value otherwise the minimum is found by default
-			break;
-		case 'n':
-			nRepeats = strtol(optarg, &chx, 10); // this sets the number of outer loop repeat without improvement
-			break;
-		case 'v':
-			Verbose_ = strtol(optarg, &chx, 10); // this sets the value of the Verbose
-			break;
-		case 'V':
-			fprintf(outFile_, " Version " VERSION " \n Compiled: " __DATE__ ","__TIME__ "\n");
-			exit(9);
-			break;
-		case 'S':
-			SubMatrix_ = strtol(optarg, &chx, 10); // this sets the size of the Partitioning Matrix
-			if ( SubMatrix_ < 10 ) {
-				if ( SubMatrix_ != 0) {
-					fprintf(stderr, "\n Error --  SubMatrix must be 0 or greater than 10.  -S %d\n ", SubMatrix_);
-					++errorCount;
-				}
-			}
+    while ((opt = getopt_long(argc, argv, "Hhi:o:v:VS:T:l:n:wmo:t:qr:o:", longopts, &option_index)) != -1) {
+        switch (opt) {
+        case 'a':
+            break;
+        case 'H':
+        case 'h':
+            print_help();
+            exit(0);
+        case 'i':
+            inFileName = optarg;
+            if ((inFile = fopen(inFileName, "r")) == NULL) {
+                fprintf(stderr, "\n\t Error - can't find/open file " "\"%s\"\n\n", optarg);
+                exit(9);
+            }
+            break;
+        case 'l':
+            Tlist_ = strtol(optarg, &chx, 10); // this sets the length of the tabu list
+            break;
+        case 'm':
+            findMax_ = true; // go for the maximum value otherwise the minimum is found by default
+            break;
+        case 'n':
+            nRepeats = strtol(optarg, &chx, 10); // this sets the number of outer loop repeat without improvement
+            break;
+        case 'v':
+            Verbose_ = strtol(optarg, &chx, 10); // this sets the value of the Verbose
+            break;
+        case 'V':
+            fprintf(outFile_, " Version " VERSION " \n Compiled: " __DATE__ ","__TIME__ "\n");
+            exit(9);
+            break;
+        case 'S':
+            SubMatrix_ = strtol(optarg, &chx, 10); // this sets the size of the Partitioning Matrix
+            if ( SubMatrix_ < 10 ) {
+                if ( SubMatrix_ != 0) {
+                    fprintf(stderr, "\n Error --  SubMatrix must be 0 or greater than 10.  -S %d\n ", SubMatrix_);
+                    ++errorCount;
+                }
+            }
 
-			if ( SubMatrix_ == 0 ) {
-				UseDwave_ = true;
-			}
-			break;
-		case 'T':
-			Target_    = strtod(optarg, (char**)NULL); // this sets desired optimal energy
-			TargetSet_ = true;
-			break;
-		case 't':
-			Time_ = strtod(optarg, (char**)NULL); // this sets the maximum runtime of the algorithm in seconds
-			break;
-		case 'o':
-			if ((outFile_ = fopen(optarg, "w")) == NULL) {
-				fprintf(stderr, "\n\t Error - can't find/write file " "\"%s\"\n\n", optarg);
-				exit(9);
-			}
-			outFileNm_ = optarg;
-			break;
-		case 'q':
-			print_qubo_format();
-			exit(0);
-			break;
-		case 'r':
-			seed = strtol(optarg, &chx, 10); // sets the seed value
-			break;
-		case 'w':
-			WriteMatrix_ = true;
-			break;
-		default: /* '?' or unknown */
-			print_help();
-			exit(0);
-			break;
-		}
-	}
-	srand( seed );
+            if ( SubMatrix_ == 0 ) {
+                UseDwave_ = true;
+            }
+            break;
+        case 'T':
+            Target_    = strtod(optarg, (char**)NULL); // this sets desired optimal energy
+            TargetSet_ = true;
+            break;
+        case 't':
+            Time_ = strtod(optarg, (char**)NULL); // this sets the maximum runtime of the algorithm in seconds
+            break;
+        case 'o':
+            if ((outFile_ = fopen(optarg, "w")) == NULL) {
+                fprintf(stderr, "\n\t Error - can't find/write file " "\"%s\"\n\n", optarg);
+                exit(9);
+            }
+            outFileNm_ = optarg;
+            break;
+        case 'q':
+            print_qubo_format();
+            exit(0);
+            break;
+        case 'r':
+            seed = strtol(optarg, &chx, 10); // sets the seed value
+            break;
+        case 'w':
+            WriteMatrix_ = true;
+            break;
+        default: /* '?' or unknown */
+            print_help();
+            exit(0);
+            break;
+        }
+    }
+    srand( seed );
 
-	if (inFile == NULL) {
-		fprintf(stderr, "\n\t%s error -- no input file (-i option) specified"
-		        "\n\n", pgmName_);
-		exit(9);
-	}
+    if (inFile == NULL) {
+        fprintf(stderr, "\n\t%s error -- no input file (-i option) specified"
+                "\n\n", pgmName_);
+        exit(9);
+    }
 
-	errorCount = read_qubo(inFileName, inFile); // read in the QUBO from file
+    errorCount = read_qubo(inFileName, inFile); // read in the QUBO from file
 
-	if ((errorCount > 0) ) {
-		fprintf(stderr, "\n\t%d Input error(s) on file \"%s\"\n\n"
-		        "\t%s has been stopped.\n\tThere is a desription "
-		        "of the .qubo file format: use %s -q to print it\n\n",
-		        errorCount, inFileName, pgmName_, pgmName_);
-		exit(1);
-	}
+    if ((errorCount > 0) ) {
+        fprintf(stderr, "\n\t%d Input error(s) on file \"%s\"\n\n"
+                "\t%s has been stopped.\n\tThere is a desription "
+                "of the .qubo file format: use %s -q to print it\n\n",
+                errorCount, inFileName, pgmName_, pgmName_);
+        exit(1);
+    }
 
-	val = (double**)malloc2D(maxNodes_, maxNodes_, sizeof(double) ); // create a 2d double array
-	fill_qubo(val, maxNodes_, nodes_, nNodes_, couplers_, nCouplers_); // move to a 2d array
+    val = (double**)malloc2D(maxNodes_, maxNodes_, sizeof(double) ); // create a 2d double array
+    fill_qubo(val, maxNodes_, nodes_, nNodes_, couplers_, nCouplers_); // move to a 2d array
 
-	if ( UseDwave_ ) {
-		dw_init();
-	}
+    if ( UseDwave_ ) {
+        dw_init();
+    }
 
-	solve(val, maxNodes_, nRepeats);
+    solve(val, maxNodes_, nRepeats);
 
-	if ( UseDwave_ ) {
-		dw_close();
-	}
-	if (Verbose_ > 3) {
-		fprintf(outFile_, "\n\t\"qbsolv  -i %s\" (%d nodes, %d couplers) - end-of-job\n\n",
-		        inFileName, nNodes_, nCouplers_);
-	}
-	exit(0);
+    if ( UseDwave_ ) {
+        dw_close();
+    }
+    if (Verbose_ > 3) {
+        fprintf(outFile_, "\n\t\"qbsolv  -i %s\" (%d nodes, %d couplers) - end-of-job\n\n",
+                inFileName, nNodes_, nCouplers_);
+    }
+    exit(0);
 
 }
 
 void  print_help(void)
 {
-	printf("\n\t%s -i infile [-o outfile] [-m] [-T] [-n] [-S SubMatrix] [-w] \n"
-	       "\t\t[-h] [-a] [-v verbosityLevel] [-V] [-q] [-t seconds]\n"
-	       "\nDESCRIPTION \n"
-	       "\tqbsolv executes a quadratic unconstrained binary optimization \n"
-	       "\t(QUBO) problem represented in a file, providing bit-vector \n"
-	       "\tresult(s) that minimizes (or optionally, maximizes) the value of \n"
-	       "\tthe objective function represented by the QUBO.  The problem is \n"
-	       "\trepresented in the QUBO(5) file format and notably is not limited \n"
-	       "\tto the size or connectivity pattern of the D-Wave system on which \n"
-	       "\tit will be executed. \n"
-	       "\t\tThe options are as follows: \n"
-	       "\t-i infile \n"
-	       "\t\tThe name of the file in which the input QUBO resides.  This \n"
-	       "\t\tis a required option. \n"
-	       "\t-o outfile \n"
-	       "\t\tThis optional argument denotes the name of the file to \n"
-	       "\t\twhich the output will be written.  The default is the \n"
-	       "\t\tstandard output. \n"
-	       "\t-a algo \n"
+    printf("\n\t%s -i infile [-o outfile] [-m] [-T] [-n] [-S SubMatrix] [-w] \n"
+           "\t\t[-h] [-a] [-v verbosityLevel] [-V] [-q] [-t seconds]\n"
+           "\nDESCRIPTION \n"
+           "\tqbsolv executes a quadratic unconstrained binary optimization \n"
+           "\t(QUBO) problem represented in a file, providing bit-vector \n"
+           "\tresult(s) that minimizes (or optionally, maximizes) the value of \n"
+           "\tthe objective function represented by the QUBO.  The problem is \n"
+           "\trepresented in the QUBO(5) file format and notably is not limited \n"
+           "\tto the size or connectivity pattern of the D-Wave system on which \n"
+           "\tit will be executed. \n"
+           "\t\tThe options are as follows: \n"
+           "\t-i infile \n"
+           "\t\tThe name of the file in which the input QUBO resides.  This \n"
+           "\t\tis a required option. \n"
+           "\t-o outfile \n"
+           "\t\tThis optional argument denotes the name of the file to \n"
+           "\t\twhich the output will be written.  The default is the \n"
+           "\t\tstandard output. \n"
+           "\t-a algo \n"
            "\t\t algorithm choice  default is o for original\n"
-	       "\t-m \n"
-	       "\t\tThis optional argument denotes to find the maximum instead \n"
-	       "\t\tof the minimum. \n"
-	       "\t-T target \n"
-	       "\t\tThis optional argument denotes to stop execution when the \n"
-	       "\t\ttarget value of the objective function is found. \n"
-	       "\t-t timeout \n"
-	       "\t\tThis optional argument stops execution when the elapsed \n"
-	       "\t\tcpu time equals or exceeds timeout value. Timeout is only checked \n"
-	       "\t\tafter completion of the main loop. Other halt values \n"
-	       "\t\tsuch as \'target\' and \'repeats\' will halt before \'timeout\'.\n"
-	       "\t\tThe default value is %8.1f.\n"
-	       "\t-n repeats \n"
-	       "\t\tThis optional argument denotes, once a new optimal value is \n"
-	       "\t\tfound, to repeat the main loop of the algorithm this number\n"
-	       "\t\tof times with no change in optimal value before stopping.  \n"
-	       "\t\tThe default value is %d. \n"
-	       "\t-S subproblemSize \n"
-	       "\t\tThis optional argument indicates the size of the sub-\n"
-	       "\t\tproblems into which the QUBO will be decomposed.  A \n"
-	       "\t\tsubproblem size of 0 (the default) indicates to use the \n"
-	       "\t\tsize known by qbsolv to be most effective for the D-Wave \n"
-	       "\t\tsystem targeted for execution.  A subproblem size greater \n"
-	       "\t\tthan zero indicates to use the given size and execute with \n"
-	       "\t\tqbsolvs internal classical tabu solver rather than using \n"
-	       "\t\tthe D-Wave system. \n"
-	       "\t-w \n"
-	       "\t\tIf present, this optional argument will print the QUBO \n"
-	       "\t\tmatrix and result in .csv format. \n"
-	       "\t-h \n"
-	       "\t\tIf present, this optional argument will print the help or \n"
-	       "\t\tusage message for qbsolv and exit without execution. \n"
-	       "\t-v verbosityLevel \n"
-	       "\t\tThis optional argument denotes the verbosity of output. A \n"
-	       "\t\tverbosityLevel of 0 (the default) will output the number of \n"
-	       "\t\tbits in the solution, the solution, and the energy of the \n"
-	       "\t\tsolution.  A verbosityLevel of 1 will output the same \n"
-	       "\t\tinformation for multiple solutions, if found. A \n"
-	       "\t\tverbosityLevel of 2 will also output more detailed \n"
-	       "\t\tinformation at each step of the algorithm.   \n"
-	       "\t-V \n"
-	       "\t\tIf present, this optional argument will emit the version \n"
-	       "\t\tnumber of the qbsolv program and exit without execution. \n"
-	       "\t-q \n"
-	       "\t\tIf present, this optional argument triggers printing the \n"
-	       "\t\tformat of the QUBO file.\n"
-	       "\t-r seed \n"
-	       "\t\tUsed to reset the seed for the random number generation \n",
-	       pgmName_, Time_, defaultRepeats);
+           "\t-m \n"
+           "\t\tThis optional argument denotes to find the maximum instead \n"
+           "\t\tof the minimum. \n"
+           "\t-T target \n"
+           "\t\tThis optional argument denotes to stop execution when the \n"
+           "\t\ttarget value of the objective function is found. \n"
+           "\t-t timeout \n"
+           "\t\tThis optional argument stops execution when the elapsed \n"
+           "\t\tcpu time equals or exceeds timeout value. Timeout is only checked \n"
+           "\t\tafter completion of the main loop. Other halt values \n"
+           "\t\tsuch as \'target\' and \'repeats\' will halt before \'timeout\'.\n"
+           "\t\tThe default value is %8.1f.\n"
+           "\t-n repeats \n"
+           "\t\tThis optional argument denotes, once a new optimal value is \n"
+           "\t\tfound, to repeat the main loop of the algorithm this number\n"
+           "\t\tof times with no change in optimal value before stopping.  \n"
+           "\t\tThe default value is %d. \n"
+           "\t-S subproblemSize \n"
+           "\t\tThis optional argument indicates the size of the sub-\n"
+           "\t\tproblems into which the QUBO will be decomposed.  A \n"
+           "\t\tsubproblem size of 0 (the default) indicates to use the \n"
+           "\t\tsize known by qbsolv to be most effective for the D-Wave \n"
+           "\t\tsystem targeted for execution.  A subproblem size greater \n"
+           "\t\tthan zero indicates to use the given size and execute with \n"
+           "\t\tqbsolvs internal classical tabu solver rather than using \n"
+           "\t\tthe D-Wave system. \n"
+           "\t-w \n"
+           "\t\tIf present, this optional argument will print the QUBO \n"
+           "\t\tmatrix and result in .csv format. \n"
+           "\t-h \n"
+           "\t\tIf present, this optional argument will print the help or \n"
+           "\t\tusage message for qbsolv and exit without execution. \n"
+           "\t-v verbosityLevel \n"
+           "\t\tThis optional argument denotes the verbosity of output. A \n"
+           "\t\tverbosityLevel of 0 (the default) will output the number of \n"
+           "\t\tbits in the solution, the solution, and the energy of the \n"
+           "\t\tsolution.  A verbosityLevel of 1 will output the same \n"
+           "\t\tinformation for multiple solutions, if found. A \n"
+           "\t\tverbosityLevel of 2 will also output more detailed \n"
+           "\t\tinformation at each step of the algorithm.   \n"
+           "\t-V \n"
+           "\t\tIf present, this optional argument will emit the version \n"
+           "\t\tnumber of the qbsolv program and exit without execution. \n"
+           "\t-q \n"
+           "\t\tIf present, this optional argument triggers printing the \n"
+           "\t\tformat of the QUBO file.\n"
+           "\t-r seed \n"
+           "\t\tUsed to reset the seed for the random number generation \n",
+           pgmName_, Time_, defaultRepeats);
 
-	return;
+    return;
 }
 
 void  print_qubo_format( void)
 {
-	const char *quboFormat =
-		"\n   A .qubo file contains data which describes an unconstrained\n"
-		"quadratic binary optimization problem.  It is an ASCII file comprise"
-		"d\nof four types of lines:\n\n"
-		"1) Comments - defined by a \"c\" in column 1.  They may appear\n"
-		"\tanywhere in the file, and are otherwise ignored.\n\n"
-		"2) One program line, which starts with p in the first column.\n"
-		"\tThe program line must be the first non-comment line in the file.\n"
-		"\tThe program line has six required fields (separated by space(s)),\n"
-		"\tas in this example:\n\n"
-		"  p   qubo  target   maxNodes   nNodes   nCouplers\n\n"
-		"    where:\n"
-		"  p          the problem line sentinel\n"
-		"  qubo       identifies the file type\n"
-		"  target     a string which identifies the topology of the problem\n"
-		"\t     and the specific problem type.  For an unconstrained problem,\n"
-		"\t     target may be \"0\" or \"unconstrained.\"   For constrained\n"
-		"\t     problems, valid strings could include \"chimera128\" or\n"
-		"\t     \"chimera512\" (among others).\n"
-		"  maxNodes   number of nodes in the topology.\n"
-		"  nNodes     number of nodes in the problem (nNodes <= maxNodes).\n"
-		"\t     Each node has a unique number and must take a value in the\n"
-		"\t     the range {0 - (maxNodes-1)}.  A duplicate node number is an\n"
-		"\t     error.  The node numbers need not be in order, and they need\n"
-		"\t     not be contiguous.\n"
-		"  nCouplers  number of couplers in the problem.  Each coupler is a\n"
-		"\t     unique connection between two different nodes.  The maximum\n"
-		"\t     number of couplers is (nNodes)^2.  A duplicate coupler is\n"
-		"\t     an error.\n\n"
-		"3) nNodes clauses.  Each clause is made up of three numbers.  The\n"
-		"\tnumbers are separated by one or more blanks.  The first two\n"
-		"\tnumbers must be integers and are the number for this node\n"
-		"\t(repeated).  The node number must be in {0 , (maxNodes-1)}.\n"
-		"\tThe third value is the weight associated with the node, may be\n"
-		"\tan integer or float, and can take on any positive or negative\n"
-		"\tvalue, or zero.\n\n"
-		"4) nCouplers clauses.  Each clause is made up of three numbers.  The\n"
-		"\tnumbers are separated by one or more blanks.  The first two\n"
-		"\tnumbers must be different integers and are the node numbers\n"
-		"\tfor this coupler.  The two values (i and j) must have (i < j).\n"
-		"\tEach number must be one of the nNodes valid node numbers (and\n"
-		"\tthus in {0, (maxNodes-1)}).  The third value is the strength\n"
-		"\tassociated with the coupler, may be an integer or float, and can\n"
-		"\ttake on any positive or negative value, but not zero.  Every node\n"
-		"\tmust connect with at least one other node (thus must have at least\n"
-		"\tone coupler connected to it).\n\n"
-		"Here is a simple QUBO file example for an unconstrained QUBO with 4\n"
-		"nodes and 6 couplers.  This example is provided to illustrate the\n"
-		"elements of a QUBO benchmark file, not to represent a real problem.\n"
-		"\n\t\tc\n"
-		"\t\tc  This is a sample .qubo file\n"
-		"\t\tc  with 4 nodes and 6 couplers\n"
-		"\t\tc\n"
-		"\t\tp  qubo  0  4  4  6 \n"
-		"\t\tc ------------------\n"
-		"\t\t0  0   3.4\n"
-		"\t\t1  1   4.5\n"
-		"\t\t2  2   2.1\n"
-		"\t\t3  3   -2.4\n"
-		"\t\tc ------------------\n"
-		"\t\t0  1   2.2\n"
-		"\t\t0  2   3.4\n"
-		"\t\t1  2   4.5\n"
-		"\t\t0  3   -2\n"
-		"\t\t0  2   3.4\n"
-		"\t\t1  2   4.5\n"
-		"\t\t0  3   -2\n"
-		"\t\t1  3   4.5678\n"
-		"\t\t2  3   -3.22\n\n";
-
-	printf("%s", quboFormat);
-	return;
+    const char *quboFormat =
+        "\n   A .qubo file contains data which describes an unconstrained\n"
+        "quadratic binary optimization problem.  It is an ASCII file comprise"
+        "d\nof four types of lines:\n\n"
+        "1) Comments - defined by a \"c\" in column 1.  They may appear\n"
+        "\tanywhere in the file, and are otherwise ignored.\n\n"
+        "2) One program line, which starts with p in the first column.\n"
+        "\tThe program line must be the first non-comment line in the file.\n"
+        "\tThe program line has six required fields (separated by space(s)),\n"
+        "\tas in this example:\n\n"
+        "  p   qubo  target   maxNodes   nNodes   nCouplers\n\n"
+        "    where:\n"
+        "  p          the problem line sentinel\n"
+        "  qubo       identifies the file type\n"
+        "  target     a string which identifies the topology of the problem\n"
+        "\t     and the specific problem type.  For an unconstrained problem,\n"
+        "\t     target may be \"0\" or \"unconstrained.\"   For constrained\n"
+        "\t     problems, valid strings could include \"chimera128\" or\n"
+        "\t     \"chimera512\" (among others).\n"
+        "  maxNodes   number of nodes in the topology.\n"
+        "  nNodes     number of nodes in the problem (nNodes <= maxNodes).\n"
+        "\t     Each node has a unique number and must take a value in the\n"
+        "\t     the range {0 - (maxNodes-1)}.  A duplicate node number is an\n"
+        "\t     error.  The node numbers need not be in order, and they need\n"
+        "\t     not be contiguous.\n"
+        "  nCouplers  number of couplers in the problem.  Each coupler is a\n"
+        "\t     unique connection between two different nodes.  The maximum\n"
+        "\t     number of couplers is (nNodes)^2.  A duplicate coupler is\n"
+        "\t     an error.\n\n"
+        "3) nNodes clauses.  Each clause is made up of three numbers.  The\n"
+        "\tnumbers are separated by one or more blanks.  The first two\n"
+        "\tnumbers must be integers and are the number for this node\n"
+        "\t(repeated).  The node number must be in {0 , (maxNodes-1)}.\n"
+        "\tThe third value is the weight associated with the node, may be\n"
+        "\tan integer or float, and can take on any positive or negative\n"
+        "\tvalue, or zero.\n\n"
+        "4) nCouplers clauses.  Each clause is made up of three numbers.  The\n"
+        "\tnumbers are separated by one or more blanks.  The first two\n"
+        "\tnumbers must be different integers and are the node numbers\n"
+        "\tfor this coupler.  The two values (i and j) must have (i < j).\n"
+        "\tEach number must be one of the nNodes valid node numbers (and\n"
+        "\tthus in {0, (maxNodes-1)}).  The third value is the strength\n"
+        "\tassociated with the coupler, may be an integer or float, and can\n"
+        "\ttake on any positive or negative value, but not zero.  Every node\n"
+        "\tmust connect with at least one other node (thus must have at least\n"
+        "\tone coupler connected to it).\n\n"
+        "Here is a simple QUBO file example for an unconstrained QUBO with 4\n"
+        "nodes and 6 couplers.  This example is provided to illustrate the\n"
+        "elements of a QUBO benchmark file, not to represent a real problem.\n"
+        "\n\t\tc\n"
+        "\t\tc  This is a sample .qubo file\n"
+        "\t\tc  with 4 nodes and 6 couplers\n"
+        "\t\tc\n"
+        "\t\tp  qubo  0  4  4  6 \n"
+        "\t\tc ------------------\n"
+        "\t\t0  0   3.4\n"
+        "\t\t1  1   4.5\n"
+        "\t\t2  2   2.1\n"
+        "\t\t3  3   -2.4\n"
+        "\t\tc ------------------\n"
+        "\t\t0  1   2.2\n"
+        "\t\t0  2   3.4\n"
+        "\t\t1  2   4.5\n"
+        "\t\t0  3   -2\n"
+        "\t\t0  2   3.4\n"
+        "\t\t1  2   4.5\n"
+        "\t\t0  3   -2\n"
+        "\t\t1  3   4.5678\n"
+        "\t\t2  3   -3.22\n\n";
+    
+    printf("%s", quboFormat);
+    return;
 }

--- a/src/readqubo.c
+++ b/src/readqubo.c
@@ -27,82 +27,82 @@ double     f;
 
 int read_qubo(const char *inFileName, FILE *inFile)
 {
-	int    lineLen;
-	size_t linecap = 0;
-	char   *line = NULL;
-	char   token[50], tokenp[50];
+    int    lineLen;
+    size_t linecap = 0;
+    char   *line = NULL;
+    char   token[50], tokenp[50];
 
-	while ((lineLen = getline(&line, &linecap, inFile)) > 0 ) {
-		lineNm++;
-		if ( strncmp(line, "c", 1) == 0 || strncmp(line, "C", 1) == 0) {
-			continue; // comment line in file
-		}
-		if ( !pFound ) {
-			if ( strncmp(line, "p", 1) == 0 || strncmp(line, "P", 1) == 0) { //found program line
-				sscanf(line, " %s %s %d %d %d %d", tokenp, token, &i, &maxNodes_, &nNodes_, &nCouplers_);
-				if ( strncmp(token, "qubo", 4) != 0 ) {
-					fprintf(stderr, " P line in %s is not a qubo, it lists as %s\n", inFileName, token);
-					exit(9);
-				} else { // it is a p qubo line :-)
-					// The p line is a header in the qubo file format
-					// now we can allocate node and coupler memory
-					if (GETMEM(nodes_, struct nodeStr_, nNodes_   ) == NULL ) {
-						BADMALLOC
-					}
-					if (GETMEM(couplers_, struct nodeStr_, nCouplers_) == NULL ) {
-						BADMALLOC
-					}
-				}
-				pFound = true;
-			} else {
-				continue; // not a comment line not a p line, so unknown, so skip it
-			}
+    while ((lineLen = getline(&line, &linecap, inFile)) > 0 ) {
+        lineNm++;
+        if ( strncmp(line, "c", 1) == 0 || strncmp(line, "C", 1) == 0) {
+            continue; // comment line in file
+        }
+        if ( !pFound ) {
+            if ( strncmp(line, "p", 1) == 0 || strncmp(line, "P", 1) == 0) { //found program line
+                sscanf(line, " %s %s %d %d %d %d", tokenp, token, &i, &maxNodes_, &nNodes_, &nCouplers_);
+                if ( strncmp(token, "qubo", 4) != 0 ) {
+                    fprintf(stderr, " P line in %s is not a qubo, it lists as %s\n", inFileName, token);
+                    exit(9);
+                } else { // it is a p qubo line :-)
+                    // The p line is a header in the qubo file format
+                    // now we can allocate node and coupler memory
+                    if (GETMEM(nodes_, struct nodeStr_, nNodes_   ) == NULL ) {
+                        BADMALLOC
+                    }
+                    if (GETMEM(couplers_, struct nodeStr_, nCouplers_) == NULL ) {
+                        BADMALLOC
+                    }
+                }
+                pFound = true;
+            } else {
+                continue; // not a comment line not a p line, so unknown, so skip it
+            }
 
-		} else { // p is been found and parsed, not a comment line so must be an input line or blank
-			if ( sscanf(line, "%d %d %lf", &i, &j, &f) == 3 ) {
-				if ( i == j ) {
-					if ( inode > nNodes_ ) {
-						fprintf(stderr, " Number of nodes exceeded at line %d %s,\n nodes= %d\n", lineNm, line, inode);
-						exit(9);
-					}
-					nodes_[inode].n1      = i;
-					nodes_[inode].n2      = j;
-					nodes_[inode++].value = f;
-				}else {
+        } else { // p is been found and parsed, not a comment line so must be an input line or blank
+            if ( sscanf(line, "%d %d %lf", &i, &j, &f) == 3 ) {
+                if ( i == j ) {
+                    if ( inode > nNodes_ ) {
+                        fprintf(stderr, " Number of nodes exceeded at line %d %s,\n nodes= %d\n", lineNm, line, inode);
+                        exit(9);
+                    }
+                    nodes_[inode].n1      = i;
+                    nodes_[inode].n2      = j;
+                    nodes_[inode++].value = f;
+                }else {
                     if ( i > j ) {
-						fprintf(stderr, " couplers first value must be > second value; at line %d:  %s"
-                              " coordinates  %d > %d \n", lineNm, line, i, j );
-						exit(9);
-					}
+                        fprintf(stderr, " couplers first value must be > second value; at line %d:  %s"
+                                " coordinates  %d > %d \n", lineNm, line, i, j );
+                        exit(9);
+                    }
 
-					if ( icoupler > nCouplers_ ) {
-						fprintf(stderr, " Number of couplers exceeded at line %d %s,\n Couplers= %d\n", lineNm, line, icoupler);
-						exit(9);
-					}
-					couplers_[icoupler].n1      = i;
-					couplers_[icoupler].n2      = j;
-					couplers_[icoupler++].value = f;
-				}
-				if ( (i + 1 > maxNodes_) || (j + 1 > maxNodes_) ) {
-					fprintf(stderr, " Coordinates out of bounds ( 0 to %d )  at line %d %s,\n %d %d\n", maxNodes_, lineNm, line, i, j);
-					exit(9);
-				}
-			}
-		}
-	}
-
-	int errors = 0;
-	if ( icoupler != nCouplers_ ) {
-		fprintf(stderr, " Number of couplers too small: couplers = %d, Ncouplers =%d\n", icoupler, nCouplers_);
-		errors++;
-	}
-	if ( inode != nNodes_ ) {
-		fprintf(stderr, " Number of nodes too small: nodes = %d, Nnodes =%d\n", inode, nNodes_);
-		errors++;
-	}
-	if ( errors > 0 ) {
-		exit(9);
-	}
-
-	return errors;
+                    if ( icoupler > nCouplers_ ) {
+                        fprintf(stderr, " Number of couplers exceeded at line %d %s,\n Couplers= %d\n", lineNm, line, icoupler);
+                        exit(9);
+                    }
+                    couplers_[icoupler].n1      = i;
+                    couplers_[icoupler].n2      = j;
+                    couplers_[icoupler++].value = f;
+                }
+                if ( (i + 1 > maxNodes_) || (j + 1 > maxNodes_) ) {
+                    fprintf(stderr, " Coordinates out of bounds ( 0 to %d )  at line %d %s,\n %d %d\n", maxNodes_, lineNm, line, i, j);
+                    exit(9);
+                }
+            }
+        }
+    }
+    
+    int errors = 0;
+    if ( icoupler != nCouplers_ ) {
+        fprintf(stderr, " Number of couplers too small: couplers = %d, Ncouplers =%d\n", icoupler, nCouplers_);
+        errors++;
+    }
+    if ( inode != nNodes_ ) {
+        fprintf(stderr, " Number of nodes too small: nodes = %d, Nnodes =%d\n", inode, nNodes_);
+        errors++;
+    }
+    if ( errors > 0 ) {
+        exit(9);
+    }
+    
+    return errors;
 }

--- a/src/solver.c
+++ b/src/solver.c
@@ -29,32 +29,32 @@
 // @returns Energy of solution evaluated by qubo
 double evaluate(int8_t *solution, uint qubo_size, double **qubo, double *flip_cost)
 {
-	double result = 0.0;
+    double result = 0.0;
 
-	for (uint ii = 0; ii < qubo_size; ii++) {
-		double row_sum = 0.0;
-		double col_sum = 0.0;
+    for (uint ii = 0; ii < qubo_size; ii++) {
+        double row_sum = 0.0;
+        double col_sum = 0.0;
 
-		// qubo an upper triangular matrix, so start right of the diagonal
-		// for the rows, and stop at the diagonal for the columns
-		for (uint jj = ii + 1; jj < qubo_size; jj++)
-			row_sum += qubo[ii][jj] * (double)solution[jj];
+        // qubo an upper triangular matrix, so start right of the diagonal
+        // for the rows, and stop at the diagonal for the columns
+        for (uint jj = ii + 1; jj < qubo_size; jj++)
+            row_sum += qubo[ii][jj] * (double)solution[jj];
 
-		for (uint jj = 0; jj < ii; jj++)
-			col_sum += qubo[jj][ii] * (double)solution[jj];
+        for (uint jj = 0; jj < ii; jj++)
+            col_sum += qubo[jj][ii] * (double)solution[jj];
 
-		// If the variable is currently 1, then by flipping it we lose
-		// what it is currently contributing (so we negate the contribution),
-		// when it is currently false, gain that ammount by flipping
-		if (solution[ii] == 1) {
-			result += row_sum + qubo[ii][ii];
-			flip_cost[ii] = -(row_sum + col_sum + qubo[ii][ii]);
-		} else {
-			flip_cost[ii] =  (row_sum + col_sum + qubo[ii][ii]);
-		}
-	}
+        // If the variable is currently 1, then by flipping it we lose
+        // what it is currently contributing (so we negate the contribution),
+        // when it is currently false, gain that ammount by flipping
+        if (solution[ii] == 1) {
+            result += row_sum + qubo[ii][ii];
+            flip_cost[ii] = -(row_sum + col_sum + qubo[ii][ii]);
+        } else {
+            flip_cost[ii] =  (row_sum + col_sum + qubo[ii][ii]);
+        }
+    }
 
-	return result;
+    return result;
 }
 
 
@@ -70,36 +70,36 @@ double evaluate(int8_t *solution, uint qubo_size, double **qubo, double *flip_co
 // @param[out] flip_cost The change in energy from flipping a bit
 // @returns New energy of the modified solution
 double evaluate_1bit(double old_energy, uint bit, int8_t *solution, uint qubo_size,
-	double **qubo, double *flip_cost)
+                     double **qubo, double *flip_cost)
 {
-	double result = old_energy + flip_cost[bit];
+    double result = old_energy + flip_cost[bit];
 
-	// Flip the bit and reverse its flip_cost
-	solution[bit] = 1 - solution[bit];
-	flip_cost[bit] = -flip_cost[bit];
+    // Flip the bit and reverse its flip_cost
+    solution[bit] = 1 - solution[bit];
+    flip_cost[bit] = -flip_cost[bit];
 
-	// Update the flip cost for all of the adjacent variables
-	if (solution[bit] == 0 ) {
-		// for rows ii up to bit, the flip_cost[ii] changes by qubo[bit][ii]
-		// for columns ii from bit+1 and higher, flip_cost[ii] changes by qubo[ii][bit]
-		// the sign of the change (positive or negative) depends on both solution[bit] and solution[ii].
-		for (uint ii = 0; ii < bit; ii++)
-			flip_cost[ii] += qubo[ii][bit]*(solution[ii]-!solution[ii]);
+    // Update the flip cost for all of the adjacent variables
+    if (solution[bit] == 0 ) {
+        // for rows ii up to bit, the flip_cost[ii] changes by qubo[bit][ii]
+        // for columns ii from bit+1 and higher, flip_cost[ii] changes by qubo[ii][bit]
+        // the sign of the change (positive or negative) depends on both solution[bit] and solution[ii].
+        for (uint ii = 0; ii < bit; ii++)
+            flip_cost[ii] += qubo[ii][bit]*(solution[ii]-!solution[ii]);
 
-		for (uint ii = bit + 1; ii < qubo_size; ii++)
-			flip_cost[ii] += qubo[bit][ii]*(solution[ii]-!solution[ii]);
+        for (uint ii = bit + 1; ii < qubo_size; ii++)
+            flip_cost[ii] += qubo[bit][ii]*(solution[ii]-!solution[ii]);
 
-	} else {
-		// if solution[bit] was a 1 before, flip_cost[ii] changes in the other direction.
-		for (uint ii = 0; ii < bit; ii++)
-			flip_cost[ii] -= qubo[ii][bit]*(solution[ii]-!solution[ii]);
+    } else {
+        // if solution[bit] was a 1 before, flip_cost[ii] changes in the other direction.
+        for (uint ii = 0; ii < bit; ii++)
+            flip_cost[ii] -= qubo[ii][bit]*(solution[ii]-!solution[ii]);
 
-		for (uint ii = bit + 1; ii < qubo_size; ii++)
-			flip_cost[ii] -= qubo[bit][ii]*(solution[ii]-!solution[ii]);
+        for (uint ii = bit + 1; ii < qubo_size; ii++)
+            flip_cost[ii] -= qubo[bit][ii]*(solution[ii]-!solution[ii]);
 
-	}
+    }
 
-	return result;
+    return result;
 }
 
 
@@ -119,38 +119,38 @@ double evaluate_1bit(double old_energy, uint bit, int8_t *solution, uint qubo_si
 // @param[in,out] t is the number of candidate bit flips performed in the entire algorithm so far
 // @returns New energy of the modified solution
 double local_search_1bit(double energy, int8_t *solution, uint qubo_size,
-	double **qubo, double *flip_cost, int64_t *t)
+                         double **qubo, double *flip_cost, int64_t *t)
 {
-	int kkstr = 0, kkend = qubo_size, kkinc;
-	int index[qubo_size];
+    int kkstr = 0, kkend = qubo_size, kkinc;
+    int index[qubo_size];
 
-	for (uint kk = 0; kk < qubo_size; kk++) {
-		index[kk] = kk;
-	}
+    for (uint kk = 0; kk < qubo_size; kk++) {
+        index[kk] = kk;
+    }
 
-	// The local search terminates at the local optima, so the moment we can't
-	// improve with a single bit flip
-	bool improve = true;
-	while (improve) {
-		improve = false;
+    // The local search terminates at the local optima, so the moment we can't
+    // improve with a single bit flip
+    bool improve = true;
+    while (improve) {
+        improve = false;
 
-		if (kkstr == 0) { // sweep top to bottom
-			shuffle_index(index, qubo_size);
-			kkstr = qubo_size - 1; kkinc = -1; kkend = 0;
-		} else { // sweep bottom to top
-			kkstr = 0; kkinc = 1; kkend = qubo_size; // got thru it backwards then reshuffle
-		}
+        if (kkstr == 0) { // sweep top to bottom
+            shuffle_index(index, qubo_size);
+            kkstr = qubo_size - 1; kkinc = -1; kkend = 0;
+        } else { // sweep bottom to top
+            kkstr = 0; kkinc = 1; kkend = qubo_size; // got thru it backwards then reshuffle
+        }
 
-		for (int kk = kkstr; kk != kkend; kk = kk + kkinc) {
-			uint bit = index[kk];
-			(*t)++;
-			if (energy + flip_cost[bit] > energy) {
-				energy  = evaluate_1bit(energy, bit, solution, qubo_size, qubo, flip_cost);
-				improve = true;
-			}
-		}
-	}
-	return energy;
+        for (int kk = kkstr; kk != kkend; kk = kk + kkinc) {
+            uint bit = index[kk];
+            (*t)++;
+            if (energy + flip_cost[bit] > energy) {
+                energy  = evaluate_1bit(energy, bit, solution, qubo_size, qubo, flip_cost);
+                improve = true;
+            }
+        }
+    }
+    return energy;
 }
 
 // Performance a local Max search improving the solution and returning the last evaluated value
@@ -164,14 +164,14 @@ double local_search_1bit(double energy, int8_t *solution, uint qubo_size,
 // @param t is the number of candidate bit flips performed in the entire algorithm so far
 // @returns New energy of the modified solution
 double local_search(int8_t *solution, int qubo_size, double **qubo,
-	double *flip_cost, int64_t *t)
+                    double *flip_cost, int64_t *t)
 {
-	double energy;
+    double energy;
 
-	// initial evaluate needed before evaluate_1bit can be used
-	energy = evaluate(solution, qubo_size, qubo, flip_cost);
-	energy = local_search_1bit(energy, solution, qubo_size, qubo, flip_cost, t); // local search to polish the change
-	return energy;
+    // initial evaluate needed before evaluate_1bit can be used
+    energy = evaluate(solution, qubo_size, qubo, flip_cost);
+    energy = local_search_1bit(energy, solution, qubo_size, qubo, flip_cost, t); // local search to polish the change
+    return energy;
 }
 
 // This function is called by solve to execute a tabu search, This is THE Tabu search
@@ -201,137 +201,137 @@ double local_search(int8_t *solution, int qubo_size, double **qubo,
 // @param target_set Do we have a target energy at which to terminate
 // @param index is the order in which to perform candidate bit flips (determined by flip_cost).
 double tabu_search(int8_t *solution, int8_t *best, uint qubo_size, double **qubo,
-	double *flip_cost, int64_t *t, int64_t iter_max,
-	int *TabuK, double target, bool target_set, int *index)
+                   double *flip_cost, int64_t *t, int64_t iter_max,
+                   int *TabuK, double target, bool target_set, int *index)
 {
 
-	uint      last_bit = 0;	// Track what the previously flipped bit was
-	bool      brk; // flag to mark a break and not a fall thru of the loop
-	double    best_energy; // best solution so far
-	double    Vlastchange; // working solution variable
-	int       nTabu;
-	double    sign;
-	int64_t thisIter;
-	int64_t increaseIter;
-	int       numIncrease = 900;
-	double    howFar;
+    uint      last_bit = 0;	// Track what the previously flipped bit was
+    bool      brk; // flag to mark a break and not a fall thru of the loop
+    double    best_energy; // best solution so far
+    double    Vlastchange; // working solution variable
+    int       nTabu;
+    double    sign;
+    int64_t thisIter;
+    int64_t increaseIter;
+    int       numIncrease = 900;
+    double    howFar;
 
-	// setup nTabu
-	// these nTabu numbers might need to be adjusted to work correctly
-	if (Tlist_ != -1) {
-		nTabu = MIN(Tlist_, (int)qubo_size + 1 ); // tabu use set tenure
-	} else {
-		if      (qubo_size <  20)  nTabu = 5;
+    // setup nTabu
+    // these nTabu numbers might need to be adjusted to work correctly
+    if (Tlist_ != -1) {
+        nTabu = MIN(Tlist_, (int)qubo_size + 1 ); // tabu use set tenure
+    } else {
+        if      (qubo_size <  20)  nTabu = 5;
         else if (qubo_size < 100)  nTabu = 10;
-		else if (qubo_size < 250)  nTabu = 12;
-		else if (qubo_size < 500)  nTabu = 13;
-		else if (qubo_size < 1000) nTabu = 21;
-		else if (qubo_size < 2500) nTabu = 29;
-		else if (qubo_size < 8000) nTabu = 34;
-		else /*qubo_size >= 8000*/ nTabu = 35;
-	}
+        else if (qubo_size < 250)  nTabu = 12;
+        else if (qubo_size < 500)  nTabu = 13;
+        else if (qubo_size < 1000) nTabu = 21;
+        else if (qubo_size < 2500) nTabu = 29;
+        else if (qubo_size < 8000) nTabu = 34;
+        else /*qubo_size >= 8000*/ nTabu = 35;
+    }
 
-	if ( findMax_ ) {
-		sign = 1.0;
-	} else {
-		sign = -1.0;
-	}
+    if ( findMax_ ) {
+        sign = 1.0;
+    } else {
+        sign = -1.0;
+    }
 
-	best_energy  = local_search(solution, qubo_size, qubo, flip_cost, t);
-	val_index_sort(index, flip_cost, qubo_size); // Create index array of sorted values
-	thisIter     = iter_max - (*t);
-	increaseIter = thisIter / 2;
-	Vlastchange  = best_energy;
+    best_energy  = local_search(solution, qubo_size, qubo, flip_cost, t);
+    val_index_sort(index, flip_cost, qubo_size); // Create index array of sorted values
+    thisIter     = iter_max - (*t);
+    increaseIter = thisIter / 2;
+    Vlastchange  = best_energy;
 
-	for (uint i = 0; i < qubo_size; i++) best[i] = solution[i]; // copy the best solution so far
-	for (uint i = 0; i < qubo_size; i++) TabuK[i] = 0; // zero out the Tabu vector
+    for (uint i = 0; i < qubo_size; i++) best[i] = solution[i]; // copy the best solution so far
+    for (uint i = 0; i < qubo_size; i++) TabuK[i] = 0; // zero out the Tabu vector
 
-	int kk, kkstr = 0, kkend = qubo_size, kkinc;
-	while (*t < iter_max) {
-		// best solution in neighbour, initialized most negative number
-		double neighbour_best = BIGNEGFP;
-		brk = false;
-		if ( kkstr == 0 ) { // sweep top to bottom
-			kkstr = qubo_size - 1; kkinc = -1; kkend = 0;
-		} else { // sweep bottom to top
-			kkstr = 0; kkinc = 1; kkend = qubo_size;
-		}
+    int kk, kkstr = 0, kkend = qubo_size, kkinc;
+    while (*t < iter_max) {
+        // best solution in neighbour, initialized most negative number
+        double neighbour_best = BIGNEGFP;
+        brk = false;
+        if ( kkstr == 0 ) { // sweep top to bottom
+            kkstr = qubo_size - 1; kkinc = -1; kkend = 0;
+        } else { // sweep bottom to top
+            kkstr = 0; kkinc = 1; kkend = qubo_size;
+        }
 
-		for (kk = kkstr; kk != kkend; kk = kk + kkinc) {
-			uint bit = index[kk];
-			if (TabuK[bit] != (int8_t)0 ) continue;
-			{
-				(*t)++;
-				double new_energy = Vlastchange + flip_cost[bit]; //  value if Q[k] bit is flipped
-				if (new_energy > best_energy) {
-					brk         = true;
-					last_bit    = bit;
-					new_energy  = evaluate_1bit(Vlastchange, bit, solution, qubo_size, qubo, flip_cost); // flip the bit and fix tables
-					Vlastchange = local_search_1bit(new_energy, solution, qubo_size, qubo, flip_cost, t); // local search to polish the change
-					val_index_sort_ns(index, flip_cost, qubo_size); // update index array of sorted values, don't shuffle index
-					best_energy = Vlastchange;
+        for (kk = kkstr; kk != kkend; kk = kk + kkinc) {
+            uint bit = index[kk];
+            if (TabuK[bit] != (int8_t)0 ) continue;
+            {
+                (*t)++;
+                double new_energy = Vlastchange + flip_cost[bit]; //  value if Q[k] bit is flipped
+                if (new_energy > best_energy) {
+                    brk         = true;
+                    last_bit    = bit;
+                    new_energy  = evaluate_1bit(Vlastchange, bit, solution, qubo_size, qubo, flip_cost); // flip the bit and fix tables
+                    Vlastchange = local_search_1bit(new_energy, solution, qubo_size, qubo, flip_cost, t); // local search to polish the change
+                    val_index_sort_ns(index, flip_cost, qubo_size); // update index array of sorted values, don't shuffle index
+                    best_energy = Vlastchange;
 
-					for (uint i = 0; i < qubo_size; i++) best[i] = solution[i]; // copy the best solution so far
+                    for (uint i = 0; i < qubo_size; i++) best[i] = solution[i]; // copy the best solution so far
 
-					if (target_set) {
-						if (Vlastchange >= (sign * target)) {
-							break;
-						}
-					}
-					howFar = ((double)(iter_max - (*t)) / (double)thisIter);
-					if (Verbose_ > 3) {
-						printf("Tabu new best %lf ,K=%d,iteration = %lld, %lf, %d\n",
-							best_energy * sign, last_bit,(long long) (*t), howFar, brk );
-					}
-					if ( howFar < 0.80  && numIncrease > 0 ) {
-						if (Verbose_ > 3) {
-							printf("Increase Itermax %lld, %lld\n", (long long) iter_max, 
-                                    (long long) (iter_max + increaseIter));
-						}
-						iter_max  += increaseIter;
-						thisIter += increaseIter;
-						numIncrease--;
-					}
-					break;
-				}
-				// Q vector unchanged
-				if (new_energy > neighbour_best) { // check for improved neighbor solution
-					last_bit = bit;   // record position
-					neighbour_best = new_energy;   // record neighbor solution value
-				}
-			}
-		}
+                    if (target_set) {
+                        if (Vlastchange >= (sign * target)) {
+                            break;
+                        }
+                    }
+                    howFar = ((double)(iter_max - (*t)) / (double)thisIter);
+                    if (Verbose_ > 3) {
+                        printf("Tabu new best %lf ,K=%d,iteration = %lld, %lf, %d\n",
+                               best_energy * sign, last_bit,(long long) (*t), howFar, brk );
+                    }
+                    if ( howFar < 0.80  && numIncrease > 0 ) {
+                        if (Verbose_ > 3) {
+                            printf("Increase Itermax %lld, %lld\n", (long long) iter_max,
+                                   (long long) (iter_max + increaseIter));
+                        }
+                        iter_max  += increaseIter;
+                        thisIter += increaseIter;
+                        numIncrease--;
+                    }
+                    break;
+                }
+                // Q vector unchanged
+                if (new_energy > neighbour_best) { // check for improved neighbor solution
+                    last_bit = bit;   // record position
+                    neighbour_best = new_energy;   // record neighbor solution value
+                }
+            }
+        }
 
-		if (target_set) {
-			if (Vlastchange >= (sign * target)) {
-				break;
-			}
-		}
-		if ( !brk ) { // this is the fall thru case and we havent tripped interior If V> VS test so flip Q[K]
-			Vlastchange = evaluate_1bit(Vlastchange, last_bit, solution, qubo_size, qubo, flip_cost);
-		}
+        if (target_set) {
+            if (Vlastchange >= (sign * target)) {
+                break;
+            }
+        }
+        if ( !brk ) { // this is the fall thru case and we havent tripped interior If V> VS test so flip Q[K]
+            Vlastchange = evaluate_1bit(Vlastchange, last_bit, solution, qubo_size, qubo, flip_cost);
+        }
 
-		uint i;
-		for (i = 0; i < qubo_size; i++) TabuK [i] =  MAX(0, TabuK[i] - 1);
+        uint i;
+        for (i = 0; i < qubo_size; i++) TabuK [i] =  MAX(0, TabuK[i] - 1);
 
-		// add some asymetry
-		if (solution[qubo_size-1] == 0) {
-			TabuK[last_bit] = nTabu + 1;
-		} else {
-			TabuK[last_bit] = nTabu - 1;
-		}
-	}
+        // add some asymetry
+        if (solution[qubo_size-1] == 0) {
+            TabuK[last_bit] = nTabu + 1;
+        } else {
+            TabuK[last_bit] = nTabu - 1;
+        }
+    }
 
- 	// copy over the best solution
-	for (uint i = 0; i < qubo_size; i++) solution[i] = best[i];
+    // copy over the best solution
+    for (uint i = 0; i < qubo_size; i++) solution[i] = best[i];
 
-	// ok, we are leaving Tabu, we can do a for sure clean up run of evaluate, to be sure we
-	// return the true evaluation of the function (given that we only do this a handfull of times)
-	double final_energy = evaluate(solution, qubo_size, qubo, flip_cost);
+    // ok, we are leaving Tabu, we can do a for sure clean up run of evaluate, to be sure we
+    // return the true evaluation of the function (given that we only do this a handfull of times)
+    double final_energy = evaluate(solution, qubo_size, qubo, flip_cost);
 
-	// Create index array of sorted values
-	val_index_sort(index, flip_cost, qubo_size);
-	return final_energy;
+    // Create index array of sorted values
+    val_index_sort(index, flip_cost, qubo_size);
+    return final_energy;
 }
 
 // reduce() computes a subQUBO (val_s) from large QUBO (val)
@@ -346,64 +346,64 @@ double tabu_search(int8_t *solution, int8_t *best, uint qubo_size, double **qubo
 // @param[out] sub_qubo is the returned subQUBO
 // @param[out] sub_solution is a current solution on the subQUBO
 void reduce(int *Icompress, double **qubo, uint sub_qubo_size, uint qubo_size,
-	double **sub_qubo, int8_t *solution, int8_t *sub_solution)
+            double **sub_qubo, int8_t *solution, int8_t *sub_solution)
 {
-	// clean out the subMatrix
-	for (uint i = 0; i < sub_qubo_size; i++) { // for each column
-		for (uint j = 0; j < sub_qubo_size; j++)
-			sub_qubo[i][j] = 0.0; // for each row
-	}
+    // clean out the subMatrix
+    for (uint i = 0; i < sub_qubo_size; i++) { // for each column
+        for (uint j = 0; j < sub_qubo_size; j++)
+            sub_qubo[i][j] = 0.0; // for each row
+    }
 
-	// fill the subMatrix
-	for (uint i = 0; i < sub_qubo_size; i++) { // for each column
-		sub_solution[i] = solution[Icompress[i]];
-		for (uint j = i; j < sub_qubo_size; j++) { // copy row
-			sub_qubo[i][j] = qubo[Icompress[i]][Icompress[j]];
-		}
-	}
+    // fill the subMatrix
+    for (uint i = 0; i < sub_qubo_size; i++) { // for each column
+        sub_solution[i] = solution[Icompress[i]];
+        for (uint j = i; j < sub_qubo_size; j++) { // copy row
+            sub_qubo[i][j] = qubo[Icompress[i]][Icompress[j]];
+        }
+    }
 
-	// The remainder of the function is clamping the sub_qubo to the
-	// solution state surrounding it.
+    // The remainder of the function is clamping the sub_qubo to the
+    // solution state surrounding it.
 
-	// Go over every variable that we are extracting
-	for (uint sub_variable = 0; sub_variable < sub_qubo_size; sub_variable++) {
-		// Get the global index of the current variable
-		int variable = Icompress[sub_variable];
-		double clamp = 0;
+    // Go over every variable that we are extracting
+    for (uint sub_variable = 0; sub_variable < sub_qubo_size; sub_variable++) {
+        // Get the global index of the current variable
+        int variable = Icompress[sub_variable];
+        double clamp = 0;
 
-		// this will keep track of the index of the next sub_qubo component,
-		// we don't include those in the clamping
-		int ji = sub_qubo_size - 1;
+        // this will keep track of the index of the next sub_qubo component,
+        // we don't include those in the clamping
+        int ji = sub_qubo_size - 1;
 
-		// Go over all other (non-extracted) variable
-		// from the highest until we reach the current variable
-		for (int j = qubo_size - 1; j > variable; j--) {
-			if ( j == Icompress[ji] ) {
-				// Found a sub_qubo element, skip it, watch for the next one
-				ji--;
-			} else {
-				clamp += qubo[variable][j] * solution[j];
-			}
-		}
+        // Go over all other (non-extracted) variable
+        // from the highest until we reach the current variable
+        for (int j = qubo_size - 1; j > variable; j--) {
+            if ( j == Icompress[ji] ) {
+                // Found a sub_qubo element, skip it, watch for the next one
+                ji--;
+            } else {
+                clamp += qubo[variable][j] * solution[j];
+            }
+        }
 
-		// Go over all other (non-extracted) variable
-		// from zero until we reach the current variable
-		ji = 0;
-		for (int j = 0; j < variable + 1; j++) {
-			if ( j == Icompress[ji] ) {
-				// Found a sub_qubo element, skip it, watch for the next one
-				ji++;
-			} else {
-				clamp += qubo[j][variable] * solution[j];
-			}
-		}
+        // Go over all other (non-extracted) variable
+        // from zero until we reach the current variable
+        ji = 0;
+        for (int j = 0; j < variable + 1; j++) {
+            if ( j == Icompress[ji] ) {
+                // Found a sub_qubo element, skip it, watch for the next one
+                ji++;
+            } else {
+                clamp += qubo[j][variable] * solution[j];
+            }
+        }
 
-		// Now that we know what the effects of the non-extracted variables
-		// are on the sub_qubo we include it by adding it as a linear
-		// bias in the sub_qubo (a diagonal matrix entry)
-		sub_qubo[sub_variable][sub_variable] += clamp;
-	}
-	return;
+        // Now that we know what the effects of the non-extracted variables
+        // are on the sub_qubo we include it by adding it as a linear
+        // bias in the sub_qubo (a diagonal matrix entry)
+        sub_qubo[sub_variable][sub_variable] += clamp;
+    }
+    return;
 }
 
 // solv_submatrix() performs QUBO optimization on a subregion.
@@ -418,12 +418,12 @@ void reduce(int *Icompress, double **qubo, uint sub_qubo_size, uint qubo_size,
 // @param TabuK is stores the list of tabu moves
 // @param index is the order in which to perform candidate bit flips (determined by Qval).
 double solv_submatrix(int8_t *solution, int8_t *best, uint qubo_size, double **qubo,
-	double *flip_cost, int64_t *t, int *TabuK, int *index)
+                      double *flip_cost, int64_t *t, int *TabuK, int *index)
 {
-	int64_t iter_max = (*t) + (int64_t)MAX((int64_t)3000, (int64_t)20000 * (int64_t)qubo_size);
+    int64_t iter_max = (*t) + (int64_t)MAX((int64_t)3000, (int64_t)20000 * (int64_t)qubo_size);
 
-	return tabu_search(solution, best, qubo_size, qubo, flip_cost,
-		t, iter_max, TabuK, Target_, false, index);
+    return tabu_search(solution, best, qubo_size, qubo, flip_cost,
+                       t, iter_max, TabuK, Target_, false, index);
 }
 
 // Entry into the overall solver from the main program
@@ -450,278 +450,278 @@ double solv_submatrix(int8_t *solution, int8_t *best, uint qubo_size, double **q
 // @param nRepeats is the number of iterations without improvement before giving up
 void solve(double **qubo, const int qubo_size, int nRepeats)
 {
-	double    *flip_cost, energy;
-	int       *TabuK, *index, *index_s, start_;
-	int8_t    *solution, *tabu_solution;
-	long      numPartCalls = 0;
-	int64_t t = 0,  IterMax;
+    double    *flip_cost, energy;
+    int       *TabuK, *index, *index_s, start_;
+    int8_t    *solution, *tabu_solution;
+    long      numPartCalls = 0;
+    int64_t t = 0,  IterMax;
 
-	start_ = clock();
-	t      = 0;
+    start_ = clock();
+    t      = 0;
 
-	// Get some memory for the larger val matrix to solve
-	if (GETMEM(solution, int8_t, qubo_size) == NULL) BADMALLOC
-	if (GETMEM(tabu_solution, int8_t, qubo_size) == NULL) BADMALLOC
-	if (GETMEM(flip_cost, double, qubo_size) == NULL) BADMALLOC
-	if (GETMEM(index, int, qubo_size) == NULL) BADMALLOC
-	if (GETMEM(TabuK, int, qubo_size) == NULL) BADMALLOC
+    // Get some memory for the larger val matrix to solve
+    if (GETMEM(solution, int8_t, qubo_size) == NULL) BADMALLOC
+        if (GETMEM(tabu_solution, int8_t, qubo_size) == NULL) BADMALLOC
+            if (GETMEM(flip_cost, double, qubo_size) == NULL) BADMALLOC
+                if (GETMEM(index, int, qubo_size) == NULL) BADMALLOC
+                    if (GETMEM(TabuK, int, qubo_size) == NULL) BADMALLOC
 
-	// get some memory for storing and shorting Q bit vectors
-	const int QLEN=20;
-	int8_t  **solution_list;
-	double *energy_list;
-	int    *solution_counts, *Qindex, NU = 0; // NU = current count of items
+                        // get some memory for storing and shorting Q bit vectors
+                        const int QLEN=20;
+    int8_t  **solution_list;
+    double *energy_list;
+    int    *solution_counts, *Qindex, NU = 0; // NU = current count of items
 
-	solution_list = (int8_t**)malloc2D(QLEN + 1, qubo_size, sizeof(int8_t));
-	if (GETMEM(energy_list, double, QLEN + 1) == NULL) BADMALLOC
-	if (GETMEM(solution_counts, int, QLEN + 1) == NULL) BADMALLOC
-	if (GETMEM(Qindex, int, QLEN + 1) == NULL) BADMALLOC
+    solution_list = (int8_t**)malloc2D(QLEN + 1, qubo_size, sizeof(int8_t));
+    if (GETMEM(energy_list, double, QLEN + 1) == NULL) BADMALLOC
+        if (GETMEM(solution_counts, int, QLEN + 1) == NULL) BADMALLOC
+            if (GETMEM(Qindex, int, QLEN + 1) == NULL) BADMALLOC
 
-	for (int i = 0; i < QLEN ; i++) {
-		energy_list[i]     = BIGNEGFP;
-		solution_counts[i] = 0;
-		for (int j = 0; j < qubo_size; j++ ) {
-			solution_list[i][j] = 0;
-		}
-	}
+                for (int i = 0; i < QLEN ; i++) {
+                    energy_list[i]     = BIGNEGFP;
+                    solution_counts[i] = 0;
+                    for (int j = 0; j < qubo_size; j++ ) {
+                        solution_list[i][j] = 0;
+                    }
+                }
 
-	// get some memory for reduced sub matrices
-	int8_t  *sub_solution, *Qt_s, *Qbest;
-	double best_energy, *sub_flip_cost, **sub_qubo;
-	int    *TabuK_s, *Icompress;
+    // get some memory for reduced sub matrices
+    int8_t  *sub_solution, *Qt_s, *Qbest;
+    double best_energy, *sub_flip_cost, **sub_qubo;
+    int    *TabuK_s, *Icompress;
 
-	sub_qubo = (double**)malloc2D(qubo_size, qubo_size, sizeof(double));
-	if (GETMEM(Icompress, int, qubo_size) == NULL) BADMALLOC
-	if (GETMEM(Qbest, int8_t, qubo_size) == NULL) BADMALLOC
-	if (GETMEM(TabuK_s, int, SubMatrix_) == NULL) BADMALLOC
-	if (GETMEM(sub_solution, int8_t, SubMatrix_) == NULL) BADMALLOC
-	if (GETMEM(Qt_s, int8_t, SubMatrix_) == NULL) BADMALLOC
-	if (GETMEM(sub_flip_cost, double, SubMatrix_) == NULL) BADMALLOC
-	if (GETMEM(index_s, int, SubMatrix_) == NULL) BADMALLOC
+    sub_qubo = (double**)malloc2D(qubo_size, qubo_size, sizeof(double));
+    if (GETMEM(Icompress, int, qubo_size) == NULL) BADMALLOC
+        if (GETMEM(Qbest, int8_t, qubo_size) == NULL) BADMALLOC
+            if (GETMEM(TabuK_s, int, SubMatrix_) == NULL) BADMALLOC
+                if (GETMEM(sub_solution, int8_t, SubMatrix_) == NULL) BADMALLOC
+                    if (GETMEM(Qt_s, int8_t, SubMatrix_) == NULL) BADMALLOC
+                        if (GETMEM(sub_flip_cost, double, SubMatrix_) == NULL) BADMALLOC
+                            if (GETMEM(index_s, int, SubMatrix_) == NULL) BADMALLOC
 
-	// initialize and set some tuning parameters
-	//
-	const int Progress_check = 12;                 // number of non progresive passes thru main loop before reset
-	const float SubMatrix_span = 0.214; // percent of the total size will be covered by the subMatrix pass
-	const int64_t InitialTabuPass_factor=6500; // initial pass factor for tabu iterations
-	const int64_t TabuPass_factor=1600.;        // iterative pass factor for tabu iterations
+                                // initialize and set some tuning parameters
+                                //
+                                const int Progress_check = 12;                 // number of non progresive passes thru main loop before reset
+    const float SubMatrix_span = 0.214; // percent of the total size will be covered by the subMatrix pass
+    const int64_t InitialTabuPass_factor=6500; // initial pass factor for tabu iterations
+    const int64_t TabuPass_factor=1600.;        // iterative pass factor for tabu iterations
 
-	const int MaxNodes_sub = MAX(SubMatrix_ + 1, SubMatrix_span * qubo_size);
-	const int subMatrix    = SubMatrix_;
-	const int l_max        = MIN(qubo_size - SubMatrix_, MaxNodes_sub);
+    const int MaxNodes_sub = MAX(SubMatrix_ + 1, SubMatrix_span * qubo_size);
+    const int subMatrix    = SubMatrix_;
+    const int l_max        = MIN(qubo_size - SubMatrix_, MaxNodes_sub);
 
-	randomize_solution(tabu_solution, qubo_size);
-	for (int i = 0; i < qubo_size; i++) {
-		index[i]    = i;   // initial index to 0,1,2,...qubo_size
-		TabuK[i]    = 0;   // initial TabuK to nothing tabu
-		solution[i] = 0;
-	}
-	for (int i = 0; i < SubMatrix_; i++) {
-		index_s[i] = i; // initial index to 0,1,2,...SubMartix_
-		sub_solution[i] = 0;
-		Qt_s[i]    = tabu_solution[i];
-	}
+    randomize_solution(tabu_solution, qubo_size);
+    for (int i = 0; i < qubo_size; i++) {
+        index[i]    = i;   // initial index to 0,1,2,...qubo_size
+        TabuK[i]    = 0;   // initial TabuK to nothing tabu
+        solution[i] = 0;
+    }
+    for (int i = 0; i < SubMatrix_; i++) {
+        index_s[i] = i; // initial index to 0,1,2,...SubMartix_
+        sub_solution[i] = 0;
+        Qt_s[i]    = tabu_solution[i];
+    }
 
-	int    l = 0, DwaveQubo = 0;
-	double sign = findMax_ ? 1.0 : -1.0;
+    int    l = 0, DwaveQubo = 0;
+    double sign = findMax_ ? 1.0 : -1.0;
 
-	// run initial Tabu Search to establish backbone
-	IterMax = t + (int64_t)MAX((int64_t)400, InitialTabuPass_factor * (int64_t)qubo_size);
-	if (Verbose_ > 2) {
-		DLT; printf(" Starting Full initial Tabu\n");
-	}
-	energy = tabu_search(solution, tabu_solution, qubo_size, qubo, flip_cost,
-		&t, IterMax, TabuK, Target_, TargetSet_, index);
+    // run initial Tabu Search to establish backbone
+    IterMax = t + (int64_t)MAX((int64_t)400, InitialTabuPass_factor * (int64_t)qubo_size);
+    if (Verbose_ > 2) {
+        DLT; printf(" Starting Full initial Tabu\n");
+    }
+    energy = tabu_search(solution, tabu_solution, qubo_size, qubo, flip_cost,
+                         &t, IterMax, TabuK, Target_, TargetSet_, index);
 
-	// save best result
-	best_energy = energy;
-	NU    = manage_solutions(solution, solution_list, energy, energy_list, solution_counts, Qindex, QLEN, qubo_size);
-	for (int i = 0; i < qubo_size; i++) Qbest[i] = solution[i];
-	val_index_sort(index, flip_cost, qubo_size); // create index array of sorted values
-	if ( Verbose_ > 0 ) {
-		print_output(qubo_size, solution, numPartCalls, best_energy * sign,
-			(double)(clock() - start_) / CLOCKS_PER_SEC);
-	}
-	if (Verbose_ > 1) {
-		DLT; printf(" V Starting outer loop =%lf iterations %lld\n", best_energy * sign, (long long) t);
-	}
+    // save best result
+    best_energy = energy;
+    NU    = manage_solutions(solution, solution_list, energy, energy_list, solution_counts, Qindex, QLEN, qubo_size);
+    for (int i = 0; i < qubo_size; i++) Qbest[i] = solution[i];
+    val_index_sort(index, flip_cost, qubo_size); // create index array of sorted values
+    if ( Verbose_ > 0 ) {
+        print_output(qubo_size, solution, numPartCalls, best_energy * sign,
+                     (double)(clock() - start_) / CLOCKS_PER_SEC);
+    }
+    if (Verbose_ > 1) {
+        DLT; printf(" V Starting outer loop =%lf iterations %lld\n", best_energy * sign, (long long) t);
+    }
 
-	// starting main search loop Partition ( run parts on tabu or Dwave ) --> Tabu rinse and repeat
-	short RepeatPass = 0, NoProgress = 0;
-	short ContinueWhile = false;
-	if ( TargetSet_ ) {
-		if ( best_energy >= (sign * Target_) ) {
-			ContinueWhile = false;
-		} else {
-			ContinueWhile = true;
-		}
-	} else {
-		if ( RepeatPass < nRepeats) {
-			ContinueWhile = true;
-		} else {
-			ContinueWhile = false;
-		}
-	}
-	if ( qubo_size < 20 || subMatrix > qubo_size ) {
-		ContinueWhile = false; // trivial problem or Submatrix won't contribute
-	}
+    // starting main search loop Partition ( run parts on tabu or Dwave ) --> Tabu rinse and repeat
+    short RepeatPass = 0, NoProgress = 0;
+    short ContinueWhile = false;
+    if ( TargetSet_ ) {
+        if ( best_energy >= (sign * Target_) ) {
+            ContinueWhile = false;
+        } else {
+            ContinueWhile = true;
+        }
+    } else {
+        if ( RepeatPass < nRepeats) {
+            ContinueWhile = true;
+        } else {
+            ContinueWhile = false;
+        }
+    }
+    if ( qubo_size < 20 || subMatrix > qubo_size ) {
+        ContinueWhile = false; // trivial problem or Submatrix won't contribute
+    }
 
-	DwaveQubo = 0;
+    DwaveQubo = 0;
 
-	// outer loop begin
-	while ( ContinueWhile ) {
-		// use the first "remove" index values to remove rows and columns from new matrix
-		// initial TabuK to nothing tabu sub_solution[i] = Q[i];
-		// create compression bit vector
+    // outer loop begin
+    while ( ContinueWhile ) {
+        // use the first "remove" index values to remove rows and columns from new matrix
+        // initial TabuK to nothing tabu sub_solution[i] = Q[i];
+        // create compression bit vector
 
-		val_index_sort(index, flip_cost, qubo_size); // Create index array of sorted values
-		if (Verbose_ > 1) printf("Reduced submatrix solution l = 0; %d, subMatrix size = %d\n",
-		                         l_max, subMatrix);
+        val_index_sort(index, flip_cost, qubo_size); // Create index array of sorted values
+        if (Verbose_ > 1) printf("Reduced submatrix solution l = 0; %d, subMatrix size = %d\n",
+                                 l_max, subMatrix);
 
-		// begin submatrix passes
-		if ( NoProgress % Progress_check == (Progress_check - 1) ) { // every Progress_check (th) loop without progess
-			// reset completely
-			randomize_solution(solution, qubo_size);
-			for (int i = 0; i < qubo_size; i++) {
-				TabuK[i] = 0;
-			}
-			if (Verbose_ > 1) {
-				DLT; printf(" \n\n Reset Q and start over Repeat = %d/%d, as no progress is exhausted %d %d\n\n\n",
-				            nRepeats, RepeatPass, NoProgress, NoProgress % Progress_check);
-			}
-		} else {
-			int change=false;
-			for (l = 0; l < l_max; l += subMatrix) {
-				if (Verbose_ > 3) printf("Submatrix starting at backbone %d\n", l);
+        // begin submatrix passes
+        if ( NoProgress % Progress_check == (Progress_check - 1) ) { // every Progress_check (th) loop without progess
+            // reset completely
+            randomize_solution(solution, qubo_size);
+            for (int i = 0; i < qubo_size; i++) {
+                TabuK[i] = 0;
+            }
+            if (Verbose_ > 1) {
+                DLT; printf(" \n\n Reset Q and start over Repeat = %d/%d, as no progress is exhausted %d %d\n\n\n",
+                            nRepeats, RepeatPass, NoProgress, NoProgress % Progress_check);
+            }
+        } else {
+            int change=false;
+            for (l = 0; l < l_max; l += subMatrix) {
+                if (Verbose_ > 3) printf("Submatrix starting at backbone %d\n", l);
 
-				for (int i = l, j = 0; i < l + subMatrix; i++) {
-					Icompress[j++] = index[i]; // create compression index
-				}
-				for (int j = 0; j < subMatrix; j++) {
-					TabuK[Icompress[j]] = 0;
-				}
-				index_sort(Icompress, subMatrix, true); // sort it for effective reduction
+                for (int i = l, j = 0; i < l + subMatrix; i++) {
+                    Icompress[j++] = index[i]; // create compression index
+                }
+                for (int j = 0; j < subMatrix; j++) {
+                    TabuK[Icompress[j]] = 0;
+                }
+                index_sort(Icompress, subMatrix, true); // sort it for effective reduction
 
-				// coarsen and reduce the problem
-				reduce(Icompress, qubo, subMatrix, qubo_size, sub_qubo, solution, sub_solution);
-				if (Verbose_ > 3) {
-					printf("Bits as set before solve ");
-					for (int j = 0; j < subMatrix; j++) printf("%d", solution[Icompress[j]]);
-					if (Verbose_ > 3) printf("\n");
-				}
-				if ( UseDwave_ ) {
-					dw_solver(sub_qubo, subMatrix, sub_solution);
-				} else {
-					solv_submatrix(sub_solution, Qt_s, subMatrix, sub_qubo, sub_flip_cost, &t, TabuK_s, index_s);
-				}
-				for (int j = 0; j < subMatrix; j++) {
-					int bit = Icompress[j];
-					if (solution[bit] != sub_solution[j] ) change=true;
-					solution[bit] = sub_solution[j];
-				}
-				if (Verbose_ > 3) {
-					printf("Bits set after solve     ");
-					for (int j = 0; j < subMatrix; j++) printf("%d", solution[Icompress[j]]);
-					printf("\n");
-				}
-				numPartCalls++;
-				DwaveQubo++;
-			}
-
-			// submatrix search did not produce any new values, so randomize those bits
-			if (!change) {
-				randomize_solution_by_index(solution, l, index );
-				if (Verbose_ > 3) {
-					printf(" Submatrix search did not produce any new values, so randomize %d bits\n",l);
-				}
-			}
-
-			// completed submatrix passes
-			if ( Verbose_ > 1 ) printf("\n");
-		}
-		if ( Verbose_ > 1 ) {
-			DLT; printf(" ***Full Tabu  -- after partition pass \n");
-		}
-		// FULL TABU run here
-
-		IterMax = t + TabuPass_factor * (int64_t)qubo_size;
-		val_index_sort(index, flip_cost, qubo_size); // Create index array of sorted values
-		energy = tabu_search(solution, tabu_solution, qubo_size, qubo, flip_cost,
-			&t, IterMax, TabuK, Target_, TargetSet_ ,index);
-		val_index_sort(index, flip_cost, qubo_size); // Create index array of sorted values
-
-		if ( Verbose_ > 1 ) {
-			DLT; printf("Latest answer  %4.5f iterations =%lld\n", energy * sign,(long long) t);
-		}
-
-		NU = manage_solutions(solution, solution_list, energy, energy_list, solution_counts, Qindex, QLEN, qubo_size);
-		int repeats;
-		repeats = NU % 10;
-		NU      = NU - repeats;
-		if ( NU == 10 ) { // better solution
-			best_energy = energy;
-			for (int i = 0; i < qubo_size; i++) Qbest[i] = solution[i];
-			RepeatPass = 0;
-
-			if ( Verbose_ > 1 ) {
-				DLT; printf(" IMPROVEMENT; RepeatPass set to %d\n", RepeatPass);
-			}
-			if ( Verbose_ > 0 ) {
-				print_output(qubo_size, Qbest, numPartCalls, best_energy * sign, (double)(clock() - start_) / CLOCKS_PER_SEC);
-			}
-		} else if ( NU == 30 || NU == 20  ) { // equal solution, but how it is different?
-			RepeatPass++;
-			if (is_array_equal(solution, Qbest, qubo_size)) {
-				NoProgress++;
-			} else {
-				for (int i = 0; i < qubo_size; i++) Qbest[i] = solution[i];
-				if ( repeats == 1 && Verbose_ > 0) { // we haven't printed this out before
-					print_output(qubo_size, Qbest, numPartCalls, best_energy * sign, (double)(clock() - start_) / CLOCKS_PER_SEC);
-				}
-			}
-		} else { // not as good as our best so far
-			RepeatPass++;
-			NoProgress++;
-			if ( Verbose_ > 1) {
-				printf("NO improvement RepeatPass =%d\n", RepeatPass);
-			}
-		}
-
-		if ( Verbose_ > 1) {
-			DLT; printf("V Best outer loop =%lf iterations %lld\n", best_energy * sign,(long long) t);
-		}
-
-		// check on, if to continue the outer loop
-		if ( TargetSet_ ) {
-			if ( best_energy >= (sign * Target_) ) {
-				ContinueWhile = false;
-			} else {
-				ContinueWhile = true;
-			}
-		} else {
-			if ( RepeatPass < nRepeats) {
-				ContinueWhile = true;
-			} else {
-				ContinueWhile = false;
-			}
-		}
-
-		// timeout test
-		if ( (double)(clock() - start_) / CLOCKS_PER_SEC >= Time_ ) {
-			ContinueWhile = false;
-		}
-	} // end of outer loop
-
-	// all done print results if needed and free allocated arrays
-	if (WriteMatrix_)
-		print_solution_and_qubo(solution, qubo_size, qubo);
-
-	if ( Verbose_ == 0 )
-		print_output(qubo_size, Qbest, numPartCalls, best_energy * sign, (double)(clock() - start_) / CLOCKS_PER_SEC);
-
-	free(solution); free(tabu_solution); free(flip_cost);
-	free(index); free(TabuK); free(energy_list); free(solution_counts); free(Qindex); free(Icompress);
-	free(Qbest); free(TabuK_s); free(sub_solution); free(Qt_s); free(qubo); free(sub_qubo);
-	free(sub_flip_cost); free (index_s); free(solution_list);
-	return;
+                // coarsen and reduce the problem
+                reduce(Icompress, qubo, subMatrix, qubo_size, sub_qubo, solution, sub_solution);
+                if (Verbose_ > 3) {
+                    printf("Bits as set before solve ");
+                    for (int j = 0; j < subMatrix; j++) printf("%d", solution[Icompress[j]]);
+                    if (Verbose_ > 3) printf("\n");
+                }
+                if ( UseDwave_ ) {
+                    dw_solver(sub_qubo, subMatrix, sub_solution);
+                } else {
+                    solv_submatrix(sub_solution, Qt_s, subMatrix, sub_qubo, sub_flip_cost, &t, TabuK_s, index_s);
+                }
+                for (int j = 0; j < subMatrix; j++) {
+                    int bit = Icompress[j];
+                    if (solution[bit] != sub_solution[j] ) change=true;
+                    solution[bit] = sub_solution[j];
+                }
+                if (Verbose_ > 3) {
+                    printf("Bits set after solve     ");
+                    for (int j = 0; j < subMatrix; j++) printf("%d", solution[Icompress[j]]);
+                    printf("\n");
+                }
+                numPartCalls++;
+                DwaveQubo++;
+            }
+            
+            // submatrix search did not produce any new values, so randomize those bits
+            if (!change) {
+                randomize_solution_by_index(solution, l, index );
+                if (Verbose_ > 3) {
+                    printf(" Submatrix search did not produce any new values, so randomize %d bits\n",l);
+                }
+            }
+            
+            // completed submatrix passes
+            if ( Verbose_ > 1 ) printf("\n");
+        }
+        if ( Verbose_ > 1 ) {
+            DLT; printf(" ***Full Tabu  -- after partition pass \n");
+        }
+        // FULL TABU run here
+        
+        IterMax = t + TabuPass_factor * (int64_t)qubo_size;
+        val_index_sort(index, flip_cost, qubo_size); // Create index array of sorted values
+        energy = tabu_search(solution, tabu_solution, qubo_size, qubo, flip_cost,
+                             &t, IterMax, TabuK, Target_, TargetSet_ ,index);
+        val_index_sort(index, flip_cost, qubo_size); // Create index array of sorted values
+        
+        if ( Verbose_ > 1 ) {
+            DLT; printf("Latest answer  %4.5f iterations =%lld\n", energy * sign,(long long) t);
+        }
+        
+        NU = manage_solutions(solution, solution_list, energy, energy_list, solution_counts, Qindex, QLEN, qubo_size);
+        int repeats;
+        repeats = NU % 10;
+        NU      = NU - repeats;
+        if ( NU == 10 ) { // better solution
+            best_energy = energy;
+            for (int i = 0; i < qubo_size; i++) Qbest[i] = solution[i];
+            RepeatPass = 0;
+            
+            if ( Verbose_ > 1 ) {
+                DLT; printf(" IMPROVEMENT; RepeatPass set to %d\n", RepeatPass);
+            }
+            if ( Verbose_ > 0 ) {
+                print_output(qubo_size, Qbest, numPartCalls, best_energy * sign, (double)(clock() - start_) / CLOCKS_PER_SEC);
+            }
+        } else if ( NU == 30 || NU == 20  ) { // equal solution, but how it is different?
+            RepeatPass++;
+            if (is_array_equal(solution, Qbest, qubo_size)) {
+                NoProgress++;
+            } else {
+                for (int i = 0; i < qubo_size; i++) Qbest[i] = solution[i];
+                if ( repeats == 1 && Verbose_ > 0) { // we haven't printed this out before
+                    print_output(qubo_size, Qbest, numPartCalls, best_energy * sign, (double)(clock() - start_) / CLOCKS_PER_SEC);
+                }
+            }
+        } else { // not as good as our best so far
+            RepeatPass++;
+            NoProgress++;
+            if ( Verbose_ > 1) {
+                printf("NO improvement RepeatPass =%d\n", RepeatPass);
+            }
+        }
+        
+        if ( Verbose_ > 1) {
+            DLT; printf("V Best outer loop =%lf iterations %lld\n", best_energy * sign,(long long) t);
+        }
+        
+        // check on, if to continue the outer loop
+        if ( TargetSet_ ) {
+            if ( best_energy >= (sign * Target_) ) {
+                ContinueWhile = false;
+            } else {
+                ContinueWhile = true;
+            }
+        } else {
+            if ( RepeatPass < nRepeats) {
+                ContinueWhile = true;
+            } else {
+                ContinueWhile = false;
+            }
+        }
+        
+        // timeout test
+        if ( (double)(clock() - start_) / CLOCKS_PER_SEC >= Time_ ) {
+            ContinueWhile = false;
+        }
+    } // end of outer loop
+    
+    // all done print results if needed and free allocated arrays
+    if (WriteMatrix_)
+        print_solution_and_qubo(solution, qubo_size, qubo);
+    
+    if ( Verbose_ == 0 )
+        print_output(qubo_size, Qbest, numPartCalls, best_energy * sign, (double)(clock() - start_) / CLOCKS_PER_SEC);
+    
+    free(solution); free(tabu_solution); free(flip_cost);
+    free(index); free(TabuK); free(energy_list); free(solution_counts); free(Qindex); free(Icompress);
+    free(Qbest); free(TabuK_s); free(sub_solution); free(Qt_s); free(qubo); free(sub_qubo);
+    free(sub_flip_cost); free (index_s); free(solution_list);
+    return;
 }

--- a/src/util.c
+++ b/src/util.c
@@ -20,126 +20,126 @@
 // X[rows][cols] addressing. Using only a single malloc
 void **malloc2D(uint rows, uint cols, uint size)
 {
-	// the total amount of memory required to hold both the matrix and the lookup table
-	uintptr_t space = rows * (sizeof(char *) + (cols * size));
-	char ** big_array = (char**)malloc(space);
-	if (big_array == NULL) {
-		DL;
-		printf("\n\t%s error - memory request for X[%d][%d], %ld Mbytes  "
-		       "denied\n\n", pgmName_, rows, cols, (long)space / 1024 / 1024 );
-		exit(9);
-	}
+    // the total amount of memory required to hold both the matrix and the lookup table
+    uintptr_t space = rows * (sizeof(char *) + (cols * size));
+    char ** big_array = (char**)malloc(space);
+    if (big_array == NULL) {
+        DL;
+        printf("\n\t%s error - memory request for X[%d][%d], %ld Mbytes  "
+               "denied\n\n", pgmName_, rows, cols, (long)space / 1024 / 1024 );
+        exit(9);
+    }
 
-	// Build a table of pointers in the first rows * sizeof(pointer)
-	// bytes of the memory, that point to the rows in the data matrix
-	space = cols * size;                     // space is now equal to the size of a row
-	char * ptr   = (char*)&big_array[rows];  // ie, &big_array[nRows]
-	for (uint i = 0; i < rows; ++i) {        // assign pointer to row, then increment pointer by size of row
-		big_array[i] = ptr;
-		ptr         += space;
-	}
-	return (void**)big_array;
+    // Build a table of pointers in the first rows * sizeof(pointer)
+    // bytes of the memory, that point to the rows in the data matrix
+    space = cols * size;                     // space is now equal to the size of a row
+    char * ptr   = (char*)&big_array[rows];  // ie, &big_array[nRows]
+    for (uint i = 0; i < rows; ++i) {        // assign pointer to row, then increment pointer by size of row
+        big_array[i] = ptr;
+        ptr         += space;
+    }
+    return (void**)big_array;
 }
 
 // this randomly sets the bit vector to 1 or 0
 void randomize_solution(int8_t *solution, int nbits)
 {
-	for (int i = 0; i < nbits; i++) {
-		solution[i] = rand() % 2;
-	}
+    for (int i = 0; i < nbits; i++) {
+        solution[i] = rand() % 2;
+    }
 }
 
 // this randomly sets the bit vector to 1 or 0, with index
 void randomize_solution_by_index(int8_t *solution, int nbits, int *indices)
 {
-	for (int i = 0; i < nbits; i++) {
-		solution[indices[i]] = rand() % 2;
-	}
+    for (int i = 0; i < nbits; i++) {
+        solution[indices[i]] = rand() % 2;
+    }
 }
 
 // shuffle the index vector before sort
 void shuffle_index(int *indices, int length)
 {
-	for (int i = length - 1; i > 0; i--) {
-		int j   = rand() % (i + 1);
-		// swap values
-		int tmp = indices[i];
-		indices[i] = indices[j];
-		indices[j] = tmp;
-	}
+    for (int i = length - 1; i > 0; i--) {
+        int j   = rand() % (i + 1);
+        // swap values
+        int tmp = indices[i];
+        indices[i] = indices[j];
+        indices[j] = tmp;
+    }
 }
 
 //  print out the bit vector as row and column, surrounding the Qubo in triangular form  used in the -w option
 void print_solution_and_qubo(int8_t *solution, int maxNodes, double **qubo)
 {
-	double sign = findMax_ ? 1.0 : -1.0;
+    double sign = findMax_ ? 1.0 : -1.0;
 
-	fprintf(outFile_, "ij, ");
-	for (int i = 0; i < maxNodes; i++) fprintf(outFile_, ",%d", i);
-	fprintf(outFile_, "\n");
+    fprintf(outFile_, "ij, ");
+    for (int i = 0; i < maxNodes; i++) fprintf(outFile_, ",%d", i);
+    fprintf(outFile_, "\n");
 
-	fprintf(outFile_, "Q,");
-	for (int i = 0; i < maxNodes; i++) fprintf(outFile_, ",%d", solution[i]);
-	fprintf(outFile_, "\n");
+    fprintf(outFile_, "Q,");
+    for (int i = 0; i < maxNodes; i++) fprintf(outFile_, ",%d", solution[i]);
+    fprintf(outFile_, "\n");
 
-	for (int i = 0; i < maxNodes; i++) {
-		fprintf(outFile_, "%d,%d,", i, solution[i]);
-		for (int j = 0; j < i; j++) fprintf(outFile_, ",");
-		for (int j = i; j < maxNodes; j++) {
-			if (qubo[i][j] != 0.0 ) {
-				fprintf(outFile_, "%6.4lf,", (qubo[i][j] * sign));
-			}else {
-				fprintf(outFile_, ",");
-			}
-		}
-		fprintf(outFile_, "\n");
-	}
+    for (int i = 0; i < maxNodes; i++) {
+        fprintf(outFile_, "%d,%d,", i, solution[i]);
+        for (int j = 0; j < i; j++) fprintf(outFile_, ",");
+        for (int j = i; j < maxNodes; j++) {
+            if (qubo[i][j] != 0.0 ) {
+                fprintf(outFile_, "%6.4lf,", (qubo[i][j] * sign));
+            }else {
+                fprintf(outFile_, ",");
+            }
+        }
+        fprintf(outFile_, "\n");
+    }
 
-	/*  print out the bit vector as row and column, surrounding the
-	 *  Qubo where both the row and col bit is set in triangular form */
-	fprintf(outFile_, "  Values that have a Q of 1 ");
+    /*  print out the bit vector as row and column, surrounding the
+     *  Qubo where both the row and col bit is set in triangular form */
+    fprintf(outFile_, "  Values that have a Q of 1 ");
 
-	fprintf(outFile_, "ij, ");
-	for (int i = 0; i < maxNodes; i++) fprintf(outFile_, ",%d", i);
-	fprintf(outFile_, "\n");
+    fprintf(outFile_, "ij, ");
+    for (int i = 0; i < maxNodes; i++) fprintf(outFile_, ",%d", i);
+    fprintf(outFile_, "\n");
 
-	fprintf(outFile_, "Q,");
-	for (int i = 0; i < maxNodes; i++) fprintf(outFile_, ",%d", solution[i]);
-	fprintf(outFile_, "\n");
+    fprintf(outFile_, "Q,");
+    for (int i = 0; i < maxNodes; i++) fprintf(outFile_, ",%d", solution[i]);
+    fprintf(outFile_, "\n");
 
-	for (int i = 0; i < maxNodes; i++) {
-		fprintf(outFile_, "%d,%d,", i, solution[i]);
-		for (int j = 0; j < i; j++) fprintf(outFile_, ",");
-		for (int j = i; j < maxNodes; j++) {
-			if (((double)solution[i] * solution[j]) * qubo[i][j] != 0 ) {
-				fprintf(outFile_, "%6.4lf,", qubo[i][j] * sign * solution[i] * solution[j]);
-			}else {
-				fprintf(outFile_, ",");
-			}
-		}
-		fprintf(outFile_, "\n");
-	}
+    for (int i = 0; i < maxNodes; i++) {
+        fprintf(outFile_, "%d,%d,", i, solution[i]);
+        for (int j = 0; j < i; j++) fprintf(outFile_, ",");
+        for (int j = i; j < maxNodes; j++) {
+            if (((double)solution[i] * solution[j]) * qubo[i][j] != 0 ) {
+                fprintf(outFile_, "%6.4lf,", qubo[i][j] * sign * solution[i] * solution[j]);
+            }else {
+                fprintf(outFile_, ",");
+            }
+        }
+        fprintf(outFile_, "\n");
+    }
 }
 
 //  This routine performs the standard output for qbsolv
 //
 void print_output(int maxNodes, int8_t *solution, long numPartCalls, double energy, double seconds)
 {
-	int i;
+    int i;
 
-	fprintf(outFile_, "%d Number of bits in solution\n", maxNodes);
-	for (i = 0; i < maxNodes; i++) {
-		fprintf(outFile_, "%d", solution[i]);
-	}
-	fprintf(outFile_, "\n");
-	fprintf(outFile_, "%8.5f Energy of solution\n", energy);
-	fprintf(outFile_, "%ld Number of Partitioned calls\n", numPartCalls);
-	fprintf(outFile_, "%8.5f seconds of classic cpu time", seconds);
-	if ( TargetSet_ ) {
-		fprintf(outFile_, " ,Target of %8.5f\n", Target_);
-	} else {
-		fprintf(outFile_, "\n");
-	}
+    fprintf(outFile_, "%d Number of bits in solution\n", maxNodes);
+    for (i = 0; i < maxNodes; i++) {
+        fprintf(outFile_, "%d", solution[i]);
+    }
+    fprintf(outFile_, "\n");
+    fprintf(outFile_, "%8.5f Energy of solution\n", energy);
+    fprintf(outFile_, "%ld Number of Partitioned calls\n", numPartCalls);
+    fprintf(outFile_, "%8.5f seconds of classic cpu time", seconds);
+    if ( TargetSet_ ) {
+        fprintf(outFile_, " ,Target of %8.5f\n", Target_);
+    } else {
+        fprintf(outFile_, "\n");
+    }
 }
 
 //  zero out and fill 2d arrary val from nodes and couplers (negate if looking for minimum)
@@ -147,48 +147,48 @@ void print_output(int maxNodes, int8_t *solution, long numPartCalls, double ener
 void fill_qubo(double **qubo, int maxNodes, struct nodeStr_ *nodes,
 	int nNodes, struct nodeStr_ *couplers, int nCouplers)
 {
-	// Zero out the qubo
-	for (int i = 0; i < maxNodes; i++) {
-		for (int j = 0; j < maxNodes; j++) {
-			qubo[i][j] = 0.0;
-		}
-	}
+    // Zero out the qubo
+    for (int i = 0; i < maxNodes; i++) {
+        for (int j = 0; j < maxNodes; j++) {
+            qubo[i][j] = 0.0;
+        }
+    }
 
-	// Copy the structs into the matrix, flip the sign if we are looking for the
-	// minimum value during the optimization.
-	if (findMax_) {
-		for (int i = 0; i < nNodes; i++) {
-			qubo[nodes[i].n1][nodes[i].n1] = nodes[i].value;
-		}
-		for (int i = 0; i < nCouplers; i++) {
-			qubo[couplers[i].n1][couplers[i].n2] = couplers[i].value;
-		}
-	} else {
-		for (int i = 0; i < nNodes; i++) {
-			qubo[nodes[i].n1][nodes[i].n1] = -nodes[i].value;
-		}
-		for (int i = 0; i < nCouplers; i++) {
-			qubo[couplers[i].n1][couplers[i].n2] = -couplers[i].value;
-		}
-	}
+    // Copy the structs into the matrix, flip the sign if we are looking for the
+    // minimum value during the optimization.
+    if (findMax_) {
+        for (int i = 0; i < nNodes; i++) {
+            qubo[nodes[i].n1][nodes[i].n1] = nodes[i].value;
+        }
+        for (int i = 0; i < nCouplers; i++) {
+            qubo[couplers[i].n1][couplers[i].n2] = couplers[i].value;
+        }
+    } else {
+        for (int i = 0; i < nNodes; i++) {
+            qubo[nodes[i].n1][nodes[i].n1] = -nodes[i].value;
+        }
+        for (int i = 0; i < nCouplers; i++) {
+            qubo[couplers[i].n1][couplers[i].n2] = -couplers[i].value;
+        }
+    }
 }
 
 int partition(double val[], int arr[], int l, int h)
 {
-	int    i, j, t;
-	double x;
+    int    i, j, t;
+    double x;
 
-	x = val[arr[h]];
-	i = (l - 1);
+    x = val[arr[h]];
+    i = (l - 1);
 
-	for (j = l; j <= h - 1; j++) {
-		if (val[arr[j]] >= x) {
-			i++;
-			t = arr[i]; arr[i] = arr[j]; arr[j] = t; // swap
-		}
-	}
-	t = arr[i + 1]; arr[i + 1] = arr[h]; arr[h] = t; // swap
-	return (i + 1);
+    for (j = l; j <= h - 1; j++) {
+        if (val[arr[j]] >= x) {
+            i++;
+            t = arr[i]; arr[i] = arr[j]; arr[j] = t; // swap
+        }
+    }
+    t = arr[i + 1]; arr[i + 1] = arr[h]; arr[h] = t; // swap
+    return (i + 1);
 }
 
 /* val[] --> Array to be sorted,
@@ -196,56 +196,56 @@ int partition(double val[], int arr[], int l, int h)
    n     --> number of elements in arrays */
 void quick_sort_iterative_index(double val[], int arr[], int n, int *stack)
 {
-	int h, l;
+    int h, l;
 
-	h = n - 1; // last index
-	l = 0; // first index
+    h = n - 1; // last index
+    l = 0; // first index
 
-	// initialize top of stack
-	int top = -1;
+    // initialize top of stack
+    int top = -1;
 
-	// push initial values of l and h to stack
-	stack[ ++top ] = l;
-	stack[ ++top ] = h;
+    // push initial values of l and h to stack
+    stack[ ++top ] = l;
+    stack[ ++top ] = h;
 
-	// Keep popping from stack while is not empty
-	while ( top >= 0 ) {
-		// Pop h and l
-		h = stack[ top-- ];
-		l = stack[ top-- ];
+    // Keep popping from stack while is not empty
+    while ( top >= 0 ) {
+        // Pop h and l
+        h = stack[ top-- ];
+        l = stack[ top-- ];
 
-		// Set pivot element at its correct position
-		// in sorted array
-		int p = partition(val, arr, l, h );
+        // Set pivot element at its correct position
+        // in sorted array
+        int p = partition(val, arr, l, h );
 
-		// If there are elements on left side of pivot,
-		// then push left side to stack
-		if ( p - 1 > l ) {
-			stack[ ++top ] = l;
-			stack[ ++top ] = p - 1;
-		}
+        // If there are elements on left side of pivot,
+        // then push left side to stack
+        if ( p - 1 > l ) {
+            stack[ ++top ] = l;
+            stack[ ++top ] = p - 1;
+        }
 
-		// If there are elements on right side of pivot,
-		// then push right side to stack
-		if ( p + 1 < h ) {
-			stack[ ++top ] = p + 1;
-			stack[ ++top ] = h;
-		}
-	}
+        // If there are elements on right side of pivot,
+        // then push right side to stack
+        if ( p + 1 < h ) {
+            stack[ ++top ] = p + 1;
+            stack[ ++top ] = h;
+        }
+    }
 }
 
 // routine to check the sort on index'ed sort
 //
 int is_index_sorted(double data[], int index[], int size)
 {
-	int i;
+    int i;
 
-	for (i = 0; i < (size - 1); i++) {
-		if (data[index[i]] < data[index[i + 1]]) {
-			return false;
-		}
-	}
-	return true;
+    for (i = 0; i < (size - 1); i++) {
+        if (data[index[i]] < data[index[i + 1]]) {
+            return false;
+        }
+    }
+    return true;
 }
 
 //
@@ -256,58 +256,58 @@ int is_index_sorted(double data[], int index[], int size)
 //
 void val_index_sort(int *index, double *val, int n)
 {
-	int i;
-	int *stack; // temp space = n + 1
-	// Create an auxiliary stack
-	if ((GETMEM(stack, int, n + 1)) == NULL) {
-		BADMALLOC
-	}
+    int i;
+    int *stack; // temp space = n + 1
+    // Create an auxiliary stack
+    if ((GETMEM(stack, int, n + 1)) == NULL) {
+        BADMALLOC
+    }
 
-	for (i = 0; i < n; i++) index[i] = i;
-	shuffle_index(index, n);
-	quick_sort_iterative_index(val, index, n, stack);
-	free(stack);
-	// check code:
-	// for (i=0;i<n-1;i++) { if (val[index[i]]<val[index[i+1]]) { DL; exit(9); } }
-	return;
+    for (i = 0; i < n; i++) index[i] = i;
+    shuffle_index(index, n);
+    quick_sort_iterative_index(val, index, n, stack);
+    free(stack);
+    // check code:
+    // for (i=0;i<n-1;i++) { if (val[index[i]]<val[index[i+1]]) { DL; exit(9); } }
+    return;
 }
 
 void val_index_sort_ns(int *index, double *val, int n)
 {
-	int i;
-	int *stack; // temp space = n + 1
-	// Create an auxiliary stack
-	if ((GETMEM(stack, int, n + 1)) == NULL) {
-		BADMALLOC
-	}
+    int i;
+    int *stack; // temp space = n + 1
+    // Create an auxiliary stack
+    if ((GETMEM(stack, int, n + 1)) == NULL) {
+        BADMALLOC
+    }
 
-	// Assure that the index array covers val[] completely
-	for (i = 0; i < n; i++) index[i] = i;
-	quick_sort_iterative_index(val, index, n, stack);
-	free(stack);
-	// check code:
-	// for (i=0;i<n-1;i++) { if (val[index[i]]<val[index[i+1]]) { DL; exit(9); } }
-	return;
+    // Assure that the index array covers val[] completely
+    for (i = 0; i < n; i++) index[i] = i;
+    quick_sort_iterative_index(val, index, n, stack);
+    free(stack);
+    // check code:
+    // for (i=0;i<n-1;i++) { if (val[index[i]]<val[index[i+1]]) { DL; exit(9); } }
+    return;
 }
 
 int compare_intsAsc( const void *p, const void *q)
 {
-	int x = *(const int*)p;
-	int y = *(const int*)q;
+    int x = *(const int*)p;
+    int y = *(const int*)q;
 
-	if (x < y) return -1; // return -1 if you want ascending, 1 if you want descending order.
-	else if (x > y) return 1; // return 1 if you want ascending, -1 if you want descending order.
-	return 0;
+    if (x < y) return -1; // return -1 if you want ascending, 1 if you want descending order.
+    else if (x > y) return 1; // return 1 if you want ascending, -1 if you want descending order.
+    return 0;
 }
 
 int compare_intsDes( const void *p, const void *q)
 {
-	int x = *(const int*)p;
-	int y = *(const int*)q;
+    int x = *(const int*)p;
+    int y = *(const int*)q;
 
-	if (x < y) return 1;       // return -1 if you want ascending, 1 if you want descending order.
-	else if (x > y) return -1; // return 1 if you want ascending, -1 if you want descending order.
-	return 0;
+    if (x < y) return 1;       // return -1 if you want ascending, 1 if you want descending order.
+    else if (x > y) return -1; // return 1 if you want ascending, -1 if you want descending order.
+    return 0;
 }
 
 //
@@ -315,22 +315,22 @@ int compare_intsDes( const void *p, const void *q)
 //
 void index_sort(int *index, int n, short forward)
 {
-	if (forward) {
-		qsort(index, n, sizeof *index, &compare_intsAsc);
-	} else {
-		qsort(index, n, sizeof *index, &compare_intsDes);
-	}
+    if (forward) {
+        qsort(index, n, sizeof *index, &compare_intsAsc);
+    } else {
+        qsort(index, n, sizeof *index, &compare_intsDes);
+    }
 }
 
 // compares two vectors, bit by bit
 bool is_array_equal( int8_t *solution_a, int8_t *solution_b, int nbits)
 {
-	for (int i = 0; i < nbits; i++) {
-		if (solution_a[i] != solution_b[i]) {
-			return false;
-		}
-	}
-	return true;
+    for (int i = 0; i < nbits; i++) {
+        if (solution_a[i] != solution_b[i]) {
+            return false;
+        }
+    }
+    return true;
 }
 
 // solution_now is the Q vector being looked at
@@ -345,143 +345,143 @@ bool is_array_equal( int8_t *solution_a, int8_t *solution_b, int nbits)
 int manage_solutions( int8_t *solution_now, int8_t **solution_list, double energy_now,
 	double *energy_list, int *solution_counts, int *list_order, int nMax, int nbits)
 {
-	// return codes
-	enum
-	{
-		NOTHING = 0,                     // nothing new, do nothing
-		NEW_HIGH_ENERGY_UNIQUE_SOL = 10, // solution is unique, highest new energy
-		DUPLICATE_HIGHEST_ENERGY = 20,   // two cases, solution is unique, duplicate energy
-		                                 //            solution is duplicate, highest energy, add the number of repeats to this value
-		DUPLICATE_ENERGY = 30,           // two cases, solution is unique, highest energy
-		                                 //            solution is duplicate, not highest, add the number of repeats to this value
-		NEW_ENERGY_UNIQUE_SOL = 40       // solution is unique, new highest energy
-	};
+    // return codes
+    enum
+    {
+        NOTHING = 0,                     // nothing new, do nothing
+        NEW_HIGH_ENERGY_UNIQUE_SOL = 10, // solution is unique, highest new energy
+        DUPLICATE_HIGHEST_ENERGY = 20,   // two cases, solution is unique, duplicate energy
+        //            solution is duplicate, highest energy, add the number of repeats to this value
+        DUPLICATE_ENERGY = 30,           // two cases, solution is unique, highest energy
+        //            solution is duplicate, not highest, add the number of repeats to this value
+        NEW_ENERGY_UNIQUE_SOL = 40       // solution is unique, new highest energy
+    };
 
-	val_index_sort_ns(list_order, energy_list, nMax); // index array of sorted energies
+    val_index_sort_ns(list_order, energy_list, nMax); // index array of sorted energies
 
-	// new high value,
-	if (energy_now > energy_list[list_order[0]] ) {
-		// we will add it to the space to an empty queue, Sort will fix it later
-		int empty_row = list_order[nMax - 1];
+    // new high value,
+    if (energy_now > energy_list[list_order[0]] ) {
+        // we will add it to the space to an empty queue, Sort will fix it later
+        int empty_row = list_order[nMax - 1];
 
-		// save the bits to Qlist first entry
-		for (int i = 0; i < nbits; i++) {
-			solution_list[empty_row][i] = solution_now[i];
-		}
+        // save the bits to Qlist first entry
+        for (int i = 0; i < nbits; i++) {
+            solution_list[empty_row][i] = solution_now[i];
+        }
 
-		energy_list[empty_row] = energy_now;
-		solution_counts[empty_row] = 1;
+        energy_list[empty_row] = energy_now;
+        solution_counts[empty_row] = 1;
 
-		// index array of sorted energies
-		val_index_sort_ns(list_order, energy_list, nMax);
+        // index array of sorted energies
+        val_index_sort_ns(list_order, energy_list, nMax);
 
-		// we have added this Qnow to the collective, might have overwritten an old one
-		return NEW_HIGH_ENERGY_UNIQUE_SOL;
-	}
+        // we have added this Qnow to the collective, might have overwritten an old one
+        return NEW_HIGH_ENERGY_UNIQUE_SOL;
+    }
 
-	// list energies are all higher than this, do nothing
-	if (energy_now < energy_list[list_order[nMax - 1]] ) {
-		return NOTHING;
-	}
+    // list energies are all higher than this, do nothing
+    if (energy_now < energy_list[list_order[nMax - 1]] ) {
+        return NOTHING;
+    }
+    
+    // new energy is in the range of our list
+    // search thru the list to see if there is an equal energy
+    for (int i = 0; i < nMax; i++) {
+        if (energy_now == energy_list[list_order[i]]) {
 
-	// new energy is in the range of our list
-	// search thru the list to see if there is an equal energy
-	for (int i = 0; i < nMax; i++) {
-		if (energy_now == energy_list[list_order[i]]) {
+            int j = i; // now have a common energy, but it could be that we have a different Q
 
-			int j = i; // now have a common energy, but it could be that we have a different Q
+            // look thru all Q's of common energy (they are ordered)
+            while (j < nMax && energy_list[list_order[j]] == energy_now) {
+                if (is_array_equal(solution_list[list_order[j]], solution_now, nbits)) {
+                    // simply mark this Q and energy as a duplicate find
+                    solution_counts[list_order[j]]++;
 
-			// look thru all Q's of common energy (they are ordered)
-			while (j < nMax && energy_list[list_order[j]] == energy_now) {
-				if (is_array_equal(solution_list[list_order[j]], solution_now, nbits)) {
-					// simply mark this Q and energy as a duplicate find
-					solution_counts[list_order[j]]++;
+                    if (energy_now == energy_list[list_order[0]]) {
+                        // duplicate energy matching another Q and equal to best energy
+                        return DUPLICATE_HIGHEST_ENERGY + solution_counts[list_order[j]];
+                    } else {
+                        // duplicate energy matching older lower energy Q
+                        return DUPLICATE_HIGHEST_ENERGY;
+                    }
+                }
+                j++;
+            }
+            
+            // fallen thru equal energies so we need to add it to the list
+            j = list_order[nMax - 1]; // add it to the worst energy position ( prefilled with worst possible value )
+            energy_list[j] = energy_now; // save energy
+            solution_counts[j] = 1; // set number of hits as this is a first
 
-					if (energy_now == energy_list[list_order[0]]) {
-						// duplicate energy matching another Q and equal to best energy
-						return DUPLICATE_HIGHEST_ENERGY + solution_counts[list_order[j]];
-					} else {
-						// duplicate energy matching older lower energy Q
-						return DUPLICATE_HIGHEST_ENERGY;
-					}
-				}
-				j++;
-			}
+            // save the bits to solution_list
+            for (int i = 0; i < nbits; i++) {
+                solution_list[j][i] = solution_now[i];
+            }
 
-			// fallen thru equal energies so we need to add it to the list
-			j = list_order[nMax - 1]; // add it to the worst energy position ( prefilled with worst possible value )
-			energy_list[j] = energy_now; // save energy
-			solution_counts[j] = 1; // set number of hits as this is a first
+            // Create index array of sorted energies
+            val_index_sort_ns(list_order, energy_list, nMax);
+            if (energy_now == energy_list[list_order[0]]) {
+                // duplicate highest energy unique Q and equal to best energy
+                return DUPLICATE_ENERGY;
+            } else {
+                // duplicate energy matching older lower energy Q
+                return DUPLICATE_ENERGY + solution_counts[j];
+            }
+        }
 
-			// save the bits to solution_list
-			for (int i = 0; i < nbits; i++) {
-				solution_list[j][i] = solution_now[i];
-			}
+        // we have spilled off the list of energies and need to add this one
+        else if (energy_now < energy_list[list_order[i]]) {
+            int j = list_order[nMax - 1]; // add it to the worst energy position as it is unique but within the list
+            energy_list[j] = energy_now; // save energy
+            solution_counts[j] = 1; // set number of hits as this is a first
 
-			// Create index array of sorted energies
-			val_index_sort_ns(list_order, energy_list, nMax);
-			if (energy_now == energy_list[list_order[0]]) {
-				// duplicate highest energy unique Q and equal to best energy
-				return DUPLICATE_ENERGY;
-			} else {
-				// duplicate energy matching older lower energy Q
-				return DUPLICATE_ENERGY + solution_counts[j];
-			}
-		}
+            // save the bits to solution_list
+            for (int i = 0; i < nbits; i++) {
+                solution_list[j][i] = solution_now[i];
+            }
 
-		// we have spilled off the list of energies and need to add this one
-		else if (energy_now < energy_list[list_order[i]]) {
-			int j = list_order[nMax - 1]; // add it to the worst energy position as it is unique but within the list
-			energy_list[j] = energy_now; // save energy
-			solution_counts[j] = 1; // set number of hits as this is a first
+            // create index array of sorted energies
+            val_index_sort_ns(list_order, energy_list, nMax);
+            return NEW_ENERGY_UNIQUE_SOL;
+        }
+    }
 
-			// save the bits to solution_list
-			for (int i = 0; i < nbits; i++) {
-				solution_list[j][i] = solution_now[i];
-			}
-
-			// create index array of sorted energies
-			val_index_sort_ns(list_order, energy_list, nMax);
-			return NEW_ENERGY_UNIQUE_SOL;
-		}
-	}
-
-	for (int iL = 0; iL < nMax; iL++)
-		printf(" %d %d %lf %d \n", list_order[iL], iL,
-			energy_list[list_order[iL]], solution_counts[list_order[iL]]);
-
-	exit(9);
+    for (int iL = 0; iL < nMax; iL++)
+        printf(" %d %d %lf %d \n", list_order[iL], iL,
+               energy_list[list_order[iL]], solution_counts[list_order[iL]]);
+    
+    exit(9);
 }
 
 // write qubo file to *filename
 void write_qubo(double **qubo, int nMax, const char *filename)
 {
-	// Try to open the file
-	FILE *file;
-	if ((file = fopen(filename, "w")) == 0) {
-		DL; printf(" failed to open %s\n", filename); exit(9);
-	}
+    // Try to open the file
+    FILE *file;
+    if ((file = fopen(filename, "w")) == 0) {
+        DL; printf(" failed to open %s\n", filename); exit(9);
+    }
 
-	// count the non-zero couplers and nodes
-	int nNodes = 0, nCouplers = 0;
-	for (int i = 0; i < nMax; i++) {
-		if (qubo[i][i] != 0.0) nNodes++;
-		for (int j = i + 1; j < nMax; j++ ) {
-			if (qubo[i][j] != 0.0) nCouplers++;
-		}
-	}
+    // count the non-zero couplers and nodes
+    int nNodes = 0, nCouplers = 0;
+    for (int i = 0; i < nMax; i++) {
+        if (qubo[i][i] != 0.0) nNodes++;
+        for (int j = i + 1; j < nMax; j++ ) {
+            if (qubo[i][j] != 0.0) nCouplers++;
+        }
+    }
 
-	// Write out the header line
-	fprintf(file, "p qubo 0 %d %d %d\n", nMax, nNodes, nCouplers);
+    // Write out the header line
+    fprintf(file, "p qubo 0 %d %d %d\n", nMax, nNodes, nCouplers);
 
-	// Write out the details for all non zero linear/quadratic elements
-	for (int i = 0; i < nMax; i++) {
-		if (qubo[i][i] != 0) fprintf(file, "%d %d %lf\n", i, i, qubo[i][i]);
-	}
-	for (int i = 0; i < nMax; i++) {
-		for (int j = i + 1; j < nMax; j++) {
-			if (qubo[i][j] != 0.0) fprintf(file, "%d %d %lf\n", i, j, qubo[i][j]);
-		}
-	}
-	fclose(file);
+    // Write out the details for all non zero linear/quadratic elements
+    for (int i = 0; i < nMax; i++) {
+        if (qubo[i][i] != 0) fprintf(file, "%d %d %lf\n", i, i, qubo[i][i]);
+    }
+    for (int i = 0; i < nMax; i++) {
+        for (int j = i + 1; j < nMax; j++) {
+            if (qubo[i][j] != 0.0) fprintf(file, "%d %d %lf\n", i, j, qubo[i][j]);
+        }
+    }
+    fclose(file);
 }


### PR DESCRIPTION
Using TABs for indentation makes code appear differently depending
on the TAB width setting of for example editors, terminals, and
version control tools.

It's rather unpractical to edit code in one appearence and then
check the changes using `git diff` on a terminal where it looks
completely different.

Especially when sharing open source code with people using all kinds
of environments (and thus TAB settings), TABs should not be used for
indentation.