### PR TITLE
CMAKE_BUILD_TYPE

### DIFF
--- a/ci/travis/cpp-coverage.sh
+++ b/ci/travis/cpp-coverage.sh
@@ -17,7 +17,7 @@ cd -
 # Build the tests
 mkdir build;
 cd build;
-cmake .. -DQBSOLV_BUILD_TESTS=ON;
+cmake .. -DQBSOLV_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug;
 make CC=$CC CXX=$CXX;
 
 # Run the tests

--- a/ci/travis/osx-cpp-coverage.sh
+++ b/ci/travis/osx-cpp-coverage.sh
@@ -23,7 +23,7 @@ popd
 # Build the tests
 mkdir build;
 cd build;
-cmake .. -DQBSOLV_BUILD_TESTS=ON;
+cmake .. -DQBSOLV_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug;
 make CC=$CC CXX=$CXX;
 
 # Run the tests

--- a/readme.md
+++ b/readme.md
@@ -22,11 +22,11 @@ To build the C library use cmake to generate a build command for your system. On
 
 ```
 mkdir build; cd build
-cmake ..
+cmake .. -DCMAKE_BUILD_TYPE=Release
 make
 ```
 
-To build the command line interface turn the cmake option `QBSOLV_BUILD_CMD` on. The command line option for cmake to di this would be `-DQBSOLV_BUILD_CMD=ON`.
+To build the command line interface turn the cmake option `QBSOLV_BUILD_CMD` on. The command line option for cmake to do this would be `-DQBSOLV_BUILD_CMD=ON`.
 
 Command Line Usage
 ------------------


### PR DESCRIPTION
 - Add note to README directing users to use `=Release`
 - Use `=Debug` for CI