### PR TITLE
:bug: Correct parenthesization in the GETMEM macro

### DIFF
--- a/src/macros.h
+++ b/src/macros.h
@@ -31,7 +31,7 @@
 #define BIGNEGFP -1.225E308
 #define flt_equals(a, b) (fabs((a) - (b)) < EPSILON)
 
-#define GETMEM(P, T, N) (P = (T*)malloc((sizeof(T) * N)))
+#define GETMEM(P, T, N) (P = (T*)malloc((sizeof(T) * (N))))
 #define BADMALLOC                                                                                    \
     {                                                                                                \
         printf("\n  ------> Exit(%d) called by %s(%s.%d)\n\n", 9, __FUNCTION__, __FILE__, __LINE__); \


### PR DESCRIPTION
Ha!  You fell for the oldest C preprocessor bug in the book.  This pull request prevents `qbsolv` from running off the end of the `energy_list` array.  As Valgrind reports:
```
==8379== Invalid write of size 8
==8379==    at 0x10FA10: solve (solver.cc:654)
==8379==    by 0x10B71D: main (main.c:259)
==8379==  Address 0x4a774d0 is 160 bytes inside a block of size 161 alloc'd
==8379==    at 0x483874F: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==8379==    by 0x10B6B2: main (main.c:255)
==8379== 
==8379== Invalid write of size 4
==8379==    at 0x10FA18: solve (solver.cc:655)
==8379==    by 0x10B71D: main (main.c:259)
==8379==  Address 0x4a77570 is 80 bytes inside a block of size 81 alloc'd
==8379==    at 0x483874F: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==8379==    by 0x10B6D4: main (main.c:256)
```